### PR TITLE
call detect_errors on the response earlier

### DIFF
--- a/R/add_item.R
+++ b/R/add_item.R
@@ -114,6 +114,7 @@ add_item <- function(
   resp <- httr2::req_perform(req_body)
 
   parsed <- RcppSimdJson::fparse(httr2::resp_body_string(resp))
+  detect_errors(parsed)
 
   data.frame(parsed)
 }
@@ -186,7 +187,7 @@ publish_layer <- function(
     )
   )
 
-  detect_errors(item_res)
+
   # fetch item_id
   item_id <- item_res[["id"]]
 


### PR DESCRIPTION
Thanks for creating and maintaining this package! I suspect my team will be making future use of it. In any case, I was having trouble publishing a layer and getting a cryptic R message when the problem was actually a permissions issue. Calling `detect_errors()` before returning the response as a data frame surfaced the issue earlier. 