### PR TITLE
Fixes the use of prepare_spatial_filter() in delete_features()

### DIFF
--- a/R/arc-add-update-delete.R
+++ b/R/arc-add-update-delete.R
@@ -170,13 +170,12 @@ update_features <- function(
 
   # Update Feature Layer
   # https://developers.arcgis.com/rest/services-reference/enterprise/update-features.htm
-
-  #  check CRS compaitibility between x and `.data`
+  # check CRS compaitibility between x and `.data`
   # feedback for rest api team:
   # it is possible to specify the CRS of the input data for adding features or spatial
   # filters, however it is _not_ possible for updating features. If it is, it is undocumented
-  # it would be nice to be able to utilize the the transformations server side rather than
-  # relying on GDAL client side.
+  # it would be nice to be able to utilize the the transformations server side
+  # rather than relying on GDAL client side.
   # ALTERNATIVELY let me provide a feature set so i can pass in CRS
   if (!identical(sf::st_crs(x), sf::st_crs(.data))) {
 
@@ -287,14 +286,17 @@ delete_features <- function(x,
     object_ids <- paste0(object_ids, collapse = ",")
   }
 
-  filter_geom <- filter_geom %||% list()
-
   # convert to the proper CRS if not missing
-  if (!rlang::is_empty(filter_geom)) {
+  if (!rlang::is_na(filter_geom)) {
+    # we extract the two CRS object
+    # then if filter_geom has no crs we use x via `coalesce_crs()`
+    x_crs <- sf::st_crs(x)
+    filt_crs <- sf::st_crs(filter_geom)
+    crs <- coalesce(filt_crs, x_crs)
     filter_geom <- prepare_spatial_filter(
       filter_geom = filter_geom,
       predicate = predicate,
-      crs = sf::crs(x)
+      crs = crs
     )
   }
 
@@ -315,6 +317,5 @@ delete_features <- function(x,
 
   jsonify::from_json(httr2::resp_body_string(resp))
 }
-
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,6 +78,9 @@ chunk_indices <- function(n, m) {
 #' coalesce_crs(x, y)
 #' @keywords internal
 coalesce_crs <- function(x, y) {
+  # DEVELOPER NOTE: there is no inheritance check for CRS class
+  # I don't know how we would provide an informative error here.
+  # dont mess up!
   x_na <- is.na(x)
   y_na <- is.na(y)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,3 +64,30 @@ chunk_indices <- function(n, m) {
   chunk_ends[n_chunks] <- n
   list(start = chunk_starts, end = chunk_ends)
 }
+
+#' Pick first non-missing CRS
+#'
+#' @param x an object of class `crs`
+#' @param y an object of class `crs`
+#'
+#' @examples
+#'
+#' x <- sf::st_crs(27572)
+#' y <- sf::st_crs(NA)
+#'
+#' coalesce_crs(x, y)
+#' @keywords internal
+coalesce_crs <- function(x, y) {
+  x_na <- is.na(x)
+  y_na <- is.na(y)
+
+  if (x_na && y_na) {
+    return(x)
+  } else if (y_na) {
+    return(x)
+  } else if (x_na) {
+    return(y)
+  } else {
+    x
+  }
+}


### PR DESCRIPTION
This PR fixes the use of `prapre_spatial_filter()` in `delete_features()`.

A new utility function `coalesce_crs()` has been added to return the frist non-missing CRS object as well. 