### PR TITLE
Respect CRS in `arc_select()` 

### DIFF
--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -218,7 +218,9 @@ collect_layer <- function(x,
     return(data.frame())
   }
 
-  if (inherits(res, "sf")) sf::st_crs(res) <- sf::st_crs(x)
+  if (inherits(res, "sf") && is.na(sf::st_crs(res))) {
+    sf::st_crs(res) <- sf::st_crs(x)
+  }
 
   res
 

--- a/tests/testthat/test-arc-select-respect-crs.R
+++ b/tests/testthat/test-arc-select-respect-crs.R
@@ -1,0 +1,16 @@
+test_that("arc_select(): CRS is respected", {
+  url <- "https://services1.arcgis.com/UWYHeuuJISiGmgXx/arcgis/rest/services/Police_District/FeatureServer/0"
+
+  epsg_code <- 2804
+
+  flayer <- arc_open(url)
+
+  res <- arc_select(flayer, crs = epsg_code, n_max = 1)
+
+  expect_identical(
+    sf::st_crs(res),
+    sf::st_crs(epsg_code)
+  )
+})
+
+


### PR DESCRIPTION
## Changes 

`collect_layer()` was properly processing the CRS via `parse_esri_json()`. Then, after combining results, the CRS was being manually set to that of the `FeatureLayer` which was incorrect when the `crs` argument is provided. This PR only set the CRS to the result when it is missing 

Adds a test to check for this condition in the future.

**Issues that this closes** 

https://github.com/R-ArcGIS/arcgislayers/issues/94

CC @elipousson 