### PR TITLE
bump to version 1.0.0 of httr2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ LazyData: true
 Imports: 
     arcgisutils (>= 0.1.0),
     cli,
-    httr2 (>= 0.2.3),
+    httr2 (>= 1.0.0),
     jsonify,
     lifecycle,
     Rcpp,

--- a/R/arc-add-update-delete.R
+++ b/R/arc-add-update-delete.R
@@ -126,7 +126,7 @@ add_features <- function(
   }
 
   # send the requests in parallel
-  all_resps <- httr2::multi_req_perform(all_reqs)
+  all_resps <- httr2::req_perform_parallel(all_reqs)
 
   # parse the responses into a data frame
   do.call(

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -192,7 +192,7 @@ collect_layer <- function(x,
   all_requests <- lapply(offsets, add_offset, req, query_params)
 
   # make all requests and store responses in list
-  all_resps <- httr2::multi_req_perform(all_requests)
+  all_resps <- httr2::req_perform_parallel(all_requests)
 
   # identify any errors
   has_error <- vapply(all_resps, function(x) inherits(x, "error"), logical(1))

--- a/R/dev-notes.R
+++ b/R/dev-notes.R
@@ -4,7 +4,7 @@
 #| 3. number of records per page
 
 #| note that we can parallelize these requests using
-#| httr2::multi_req_perform() and curl::new_pool()
+#| httr2::req_perform_parallel() and curl::new_pool()
 #| this can make fetching data from AGOL super duper fast
 
 


### PR DESCRIPTION

## Changes 

This bumps the required version of httr2 to 1.0.0. It was announced for GA this week and the function multi_req_perform was renamed. Which is a breaking change.

**Issues that this closes** 

https://github.com/R-ArcGIS/arcgislayers/issues/93

