### PR TITLE
add lifecycle badges to exported functions #85

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,3 +9,4 @@
   - new utility function `list_items()`
 - adds cli as an explicit import (has been implicitly imported by httr2)
 - repository made public
+- add lifecycle badges to all exported functions <https://github.com/R-ArcGIS/arcgislayers/pull/101>

--- a/R/arc-add-update-delete.R
+++ b/R/arc-add-update-delete.R
@@ -15,6 +15,8 @@
 #'
 #' @details
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' Regarding the `match_on` argument:when publishing an object to an ArcGIS Portal
 #' from R, the object's names are provided as the alias. The object's names are
 #' subject to change according to the standards of the ArcGIS REST API. For example.

--- a/R/arc-raster.R
+++ b/R/arc-raster.R
@@ -14,6 +14,10 @@
 #' @param height default `NULL`. Cannot exceed `x[["maxImageHeight"]]`.
 #' @param token authorization token fetched from the environment variable `ARCGIS_TOKEN`
 #'
+#' @details
+#'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @examples
 #' if (interactive()) {
 #' img_url <- "https://landsat2.arcgis.com/arcgis/rest/services/Landsat/MS/ImageServer"

--- a/R/create-service.R
+++ b/R/create-service.R
@@ -21,6 +21,10 @@
 #' If a `FeatureServer` is cerated successfully, a `FeatureServer` object is returned
 #' based on the newly created feature server's url.
 #'
+#' @details
+#'
+#' `r lifecycle::badge("experimental")`
+#'
 #' @export
 create_feature_server <- function(
     service_name,

--- a/R/utils-feature-server.R
+++ b/R/utils-feature-server.R
@@ -9,6 +9,8 @@
 #' @inheritParams arc_open
 #' @details
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' The `id` and `name` arguments must match the field values of the respective names as seen in the output of `list_items()`
 #'
 #' @returns

--- a/R/utils-spatial-filter.R
+++ b/R/utils-spatial-filter.R
@@ -12,6 +12,8 @@
 #'
 #' @details Using `sfc` objects as `filter_geom`
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #'  If an `sfc` object is provided it will be transformed to the layers spatial
 #'  reference. If the `sfc` is missing a CRS (or is an `sfg` object) it is
 #'  assumed to use the same spatial reference as the FeatureLayer. If the `sfc`

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,6 +2,8 @@
 #'
 #' @details
 #'
+#' `r lifecycle::badge("experimental")`
+#'
 #' - `list_fields()` returns a data.frame of the fields in a `FeatureLayer` or `Table`
 #' - `list_items()` returns a data.frame containing the layers or tables in a `FeatureServer` or `MapServer`
 #' - `clear_query()` removes any saved query in a `FeatureLayer` or `Table` object

--- a/man/arc_raster.Rd
+++ b/man/arc_raster.Rd
@@ -46,6 +46,9 @@ An object of class \code{SpatRaster}.
 Given an \code{ImageServer} export an image as a \code{SpatRaster} from the terra package.
 See \code{\link[terra:rast]{terra::rast}}.
 }
+\details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+}
 \examples{
 if (interactive()) {
 img_url <- "https://landsat2.arcgis.com/arcgis/rest/services/Landsat/MS/ImageServer"

--- a/man/create_feature_server.Rd
+++ b/man/create_feature_server.Rd
@@ -60,3 +60,6 @@ based on the newly created feature server's url.
 \description{
 Create a FeatureServer
 }
+\details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+}

--- a/man/get_layer.Rd
+++ b/man/get_layer.Rd
@@ -34,5 +34,7 @@ These helpers provide easy access to the layers contained in a
 \code{FeatureServer} or \code{MapServer}.
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 The \code{id} and \code{name} arguments must match the field values of the respective names as seen in the output of \code{list_items()}
 }

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -70,6 +70,8 @@ Delete features from a feature layer based on object ID, a where clause, or a
 spatial filter.
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 Regarding the \code{match_on} argument:when publishing an object to an ArcGIS Portal
 from R, the object's names are provided as the alias. The object's names are
 subject to change according to the standards of the ArcGIS REST API. For example.

--- a/man/spatial_filter.Rd
+++ b/man/spatial_filter.Rd
@@ -47,6 +47,8 @@ to a type of ESRI spatial relation.
 \details{
 Using \code{sfc} objects as \code{filter_geom}
 
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
 If an \code{sfc} object is provided it will be transformed to the layers spatial
 reference. If the \code{sfc} is missing a CRS (or is an \code{sfg} object) it is
 assumed to use the same spatial reference as the FeatureLayer. If the \code{sfc}

--- a/man/utils.Rd
+++ b/man/utils.Rd
@@ -19,6 +19,7 @@ refresh_layer(x)
 Utility functions
 }
 \details{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 \itemize{
 \item \code{list_fields()} returns a data.frame of the fields in a \code{FeatureLayer} or \code{Table}
 \item \code{list_items()} returns a data.frame containing the layers or tables in a \code{FeatureServer} or \code{MapServer}


### PR DESCRIPTION
## Checklist 

- [✅] update NEWS.md
- [✅] documentation updated with `devtools::document()`
- [ ? ] `devtools::check()` passes locally

Got 2 errors ✖ | 4 warnings ✖ | 2 notes ✖ with `devtools::check()`.

## Changes 

Your example badges were included in the details section of the docs. Some functions - like `arc_raster()` - lacked details. In that case, I added a details section. 

**Issues that this closes** 

Closes: https://github.com/R-ArcGIS/arcgislayers/issues/85

## Follow up tasks

Found this when I ran `check()`: https://github.com/R-ArcGIS/arcgislayers/issues/102
Got this error running examples: Error in coalesce_crs(x, y) : could not find function "coalesce_crs"
In the tests: Error in `expect_fals("sf" %in% class(res))`: could not find function "expect_fals"