### PR TITLE
remove n from attributes and print method. update tests

### DIFF
--- a/R/arc-open.R
+++ b/R/arc-open.R
@@ -90,23 +90,11 @@ arc_open <- function(url, token = Sys.getenv("ARCGIS_TOKEN")) {
     "FeatureLayer" =  structure(
       meta,
       class = layer_class,
-      # if the layer does not have a query capability return NA for the attr
-      n = ifelse(
-        grepl("query", meta[["capabilities"]], TRUE),
-        count_features(req, token),
-        NA
-      ),
       query = list()
     ),
     "Table" = structure(
       meta,
       class = layer_class,
-      # if the layer does not have a query capability return NA for the attr
-      n = ifelse(
-        grepl("query", meta[["capabilities"]], TRUE),
-        count_features(req, token),
-        NA
-      ),
       query = list()
     ),
     "FeatureServer" = structure(

--- a/R/print-methods.R
+++ b/R/print-methods.R
@@ -12,10 +12,7 @@ print.Table <- function(x, ...) {
   # filter out any 0 character strings
   print_index <- vapply(to_print, nzchar, logical(1))
 
-  header <- sprintf(
-    "<%s <%i features, %i fields>>",
-    class(x), attr(x, "n"), length(x$fields$name)
-  )
+  header <- "<Table>"
 
   # print only metadata that has values
   body <- paste0(
@@ -54,8 +51,6 @@ head.Table <- function(x, n = 6, token = Sys.getenv("ARCGIS_TOKEN"), ...) {
 
 # Feature Layer -----------------------------------------------------------
 
-
-
 # Print method for feature layer objects
 #
 #' @export
@@ -65,15 +60,10 @@ print.FeatureLayer <- function(x, ...) {
     "Name" = x[["name"]],
     "Geometry Type" = x[["geometryType"]],
     "CRS" = x[["extent"]][["spatialReference"]][["latestWkid"]],
-    #"Query Formats" = x[["supportedQueryFormats"]],
     "Capabilities" = x[["capabilities"]]
   ))
 
-  header <- sprintf(
-    "<%s <%i features, %i fields>>",
-    class(x), attr(x, "n"), length(x$fields$name)
-  )
-
+  header <- "<FeatureLayer>"
   body <- paste0(names(to_print), ": ", to_print)
 
   # cat out

--- a/tests/testthat/test-arc_open.R
+++ b/tests/testthat/test-arc_open.R
@@ -1,46 +1,41 @@
-# Note that all expectations are expect_true(TRUE)
-# if an error happens before hand the test will fail.
 # These tests test that the service can be read correctly.
 # can be improved to check attributes like query, class, etc.
 
-test_that("arc_open: Feature Layer", {
+test_that("arc_open(): Feature Layer", {
   ft_url <- "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Counties_Generalized_Boundaries/FeatureServer/0"
 
-  arc_open(ft_url)
-
-  expect_true(TRUE)
+  expect_no_error(arc_open(ft_url))
 
 })
 
 
-test_that("arc_open: Table", {
+test_that("arc_open(): Table", {
 
   tbl_url <- "https://services2.arcgis.com/j80Jz20at6Bi0thr/ArcGIS/rest/services/List_of_Providers/FeatureServer/27"
 
-  arc_open(tbl_url)
-
-  expect_true(TRUE)
+  expect_no_error(arc_open(tbl_url))
 })
 
-test_that("arc_open: Feature Server", {
+test_that("arc_open(): Feature Server", {
 
   server_url <- "https://services2.arcgis.com/j80Jz20at6Bi0thr/ArcGIS/rest/services/hexagons_state/FeatureServer"
-
-  arc_open(server_url)
-
-  expect_true(TRUE)
+  expect_no_error(arc_open(server_url))
 
 })
 
+test_that("arc_open(): Map Server", {
+  map_url <- paste0(
+    "https://services.arcgisonline.com/ArcGIS/rest/services/",
+    "World_Imagery/MapServer"
+  )
 
+  expect_no_error(arc_open(map_url))
+})
 
-test_that("arc_open: Image Server", {
+test_that("arc_open(): Image Server", {
   img_url <- "https://landsat2.arcgis.com/arcgis/rest/services/Landsat/MS/ImageServer"
 
-  arc_open(img_url, token = "") # hella weird behavior with token here.
-
-  expect_true(TRUE)
-
+  expect_no_error(arc_open(img_url, token = "")) # hella weird behavior with token here.
 })
 
 

--- a/tests/testthat/test-arc_select.R
+++ b/tests/testthat/test-arc_select.R
@@ -3,10 +3,8 @@ test_that("arc_select(): polygons can be parsed", {
   furl <- "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Counties_Generalized_Boundaries/FeatureServer/0"
   flayer <- arc_open(furl)
 
-  arc_select(flayer)
+  expect_no_error(arc_select(flayer))
 
-  # if any errors occur above here the test will fail
-  expect_true(TRUE)
 })
 
 
@@ -15,11 +13,7 @@ test_that("arc_select(): tables can be parsed", {
   furl <- "https://services2.arcgis.com/j80Jz20at6Bi0thr/ArcGIS/rest/services/List_of_Providers/FeatureServer/27"
 
   tblayer <- arc_open(furl)
-
-  arc_select(tblayer)
-
-  # if any errors occur above here the test will fail
-  expect_true(TRUE)
+  expect_no_error(arc_select(tblayer))
 })
 
 

--- a/tests/testthat/test-return-geometry.R
+++ b/tests/testthat/test-return-geometry.R
@@ -20,5 +20,5 @@ test_that("arc_select(): ignores geometry for tables", {
   expect_false("sf" %in% class(res))
 
   res <- arc_select(flayer, n_max = 3, geometry = TRUE)
-  expect_fals("sf" %in% class(res))
+  expect_false("sf" %in% class(res))
 })


### PR DESCRIPTION
## Changes 

Removes the attribute n from Tables and FeatureLayers as well as adjusts their print methods. Updates some tests as well which were lazily written

**Issues that this closes** 

Closes https://github.com/R-ArcGIS/arcgislayers/issues/121
