### PR TITLE
use arc_token() to handle empty tokens

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ License: Apache License (>= 2)
 Encoding: UTF-8
 LazyData: true
 Imports: 
-    arcgisutils (>= 0.1.0),
+    arcgisutils (>= 0.1.1.9000),
     cli,
     httr2 (>= 1.0.0),
     jsonify,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     terra,
     utils
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Suggests: 
     dbplyr,
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,3 +14,4 @@
 - adds cli as an explicit import (has been implicitly imported by httr2)
 - repository made public
 - add lifecycle badges to all exported functions <https://github.com/R-ArcGIS/arcgislayers/pull/101>
+- Use `arcgisutils::arc_token()` to get "ARCGIS_TOKEN" environment variable. This ensures that empty strings do not cause HTTP 498 "invalid token" error.

--- a/R/add_item.R
+++ b/R/add_item.R
@@ -69,7 +69,7 @@ add_item <- function(
     async = FALSE,
     type = "Feature Service",
     host = arc_host(),
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
 
   # if async = TRUE stop
@@ -171,7 +171,7 @@ publish_item <- function(
     publish_params = .publish_params(),
     file_type = "featureCollection",
     host = arc_host(),
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
 
   # create request URL
@@ -208,7 +208,7 @@ publish_layer <- function(
     user = Sys.getenv("ARCGIS_USER"),
     publish_params = .publish_params(title, target_crs = sf::st_crs(x)),
     host = arc_host(),
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
 
   adtl_args <- rlang::list2(...)

--- a/R/arc-add-update-delete.R
+++ b/R/arc-add-update-delete.R
@@ -54,7 +54,7 @@ add_features <- function(
     chunk_size = 2000,
     match_on = c("name", "alias"),
     rollback_on_failure = TRUE,
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
 
   # initial check for type of `x`
@@ -180,7 +180,7 @@ update_features <- function(
     x,
     .data,
     match_on = c("name", "alias"),
-    token = Sys.getenv("ARCGIS_TOKEN"),
+    token = arc_token(),
     rollback_on_failure = TRUE,
     ...
 ) {
@@ -293,7 +293,7 @@ delete_features <- function(
     filter_geom = NULL,
     predicate = "intersects",
     rollback_on_failure = TRUE,
-    token = Sys.getenv("ARCGIS_TOKEN"),
+    token = arc_token(),
     ...
 ) {
 

--- a/R/arc-open.R
+++ b/R/arc-open.R
@@ -57,7 +57,7 @@
 #'  arc_open(map_url)
 #'
 #'}
-arc_open <- function(url, token = Sys.getenv("ARCGIS_TOKEN")) {
+arc_open <- function(url, token = arc_token()) {
 
   stopifnot("`url` must be of length 1" = length(url) == 1)
 

--- a/R/arc-raster.R
+++ b/R/arc-raster.R
@@ -54,7 +54,7 @@ arc_raster <- function(
     width = NULL,
     height = NULL,
     format = "tiff",
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
 
 

--- a/R/arc-read.R
+++ b/R/arc-read.R
@@ -62,7 +62,7 @@ arc_read <- function(
     crs = NULL,
     ...,
     fields = NULL,
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
   service <- arc_open(url = url, token = token)
 

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -57,7 +57,7 @@ arc_select <- function(
     filter_geom = NULL,
     predicate = "intersects",
     n_max = Inf,
-    token = Sys.getenv("ARCGIS_TOKEN"),
+    token = arc_token(),
     ...
 ) {
   # Developer note:
@@ -132,7 +132,7 @@ arc_select <- function(
 #' @noRd
 collect_layer <- function(x,
                           n_max = Inf,
-                          token = Sys.getenv("ARCGIS_TOKEN"),
+                          token = arc_token(),
                           ...,
                           error_call = rlang::caller_env()) {
   check_inherits_any(

--- a/R/create-service.R
+++ b/R/create-service.R
@@ -48,7 +48,7 @@ create_feature_server <- function(
     has_static_data = FALSE,
     xss_prevention = xss_defaults(),
     host = arc_host(),
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
 
   match.arg(capabilities, several.ok = TRUE)

--- a/R/get-estimates.R
+++ b/R/get-estimates.R
@@ -35,6 +35,10 @@ get_layer_estimates <- function(x, token = arc_token()) {
     "getEstimates"
   )
 
+  resp <- httr2::req_perform(
+      httr2::req_url_query(est_req, f = "json")
+  )
+
   # process json string
   res_raw <- RcppSimdJson::fparse(httr2::resp_body_string(resp))
 

--- a/R/get-estimates.R
+++ b/R/get-estimates.R
@@ -35,21 +35,6 @@ get_layer_estimates <- function(x, token = arc_token()) {
     "getEstimates"
   )
 
-  # token bug :[
-  if (token != "") {
-    req <-
-      httr2::req_auth_bearer_token(
-        httr2::req_url_query(est_req, f = "json"),
-        token
-      )
-      resp <-  httr2::req_perform(req)
-  } else {
-    resp <-
-      httr2::req_perform(
-        httr2::req_url_query(est_req, f = "json")
-      )
-  }
-
   # process json string
   res_raw <- RcppSimdJson::fparse(httr2::resp_body_string(resp))
 

--- a/R/get-estimates.R
+++ b/R/get-estimates.R
@@ -15,7 +15,7 @@
 #' @returns
 #' A named list containing all estimate info. If `extent` is present,
 #' it is available as an object of class `bbox`.
-get_layer_estimates <- function(x, token = Sys.getenv("ARCGIS_TOKEN")) {
+get_layer_estimates <- function(x, token = arc_token()) {
 
   # check if its a supported layer
   obj_check_layer(x)

--- a/R/truncate.R
+++ b/R/truncate.R
@@ -33,7 +33,7 @@ truncate_layer <- function(
     x,
     async = FALSE,
     attachment_only = FALSE,
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
 
   # check to see if it is a compatible class

--- a/R/utils-feature-server.R
+++ b/R/utils-feature-server.R
@@ -36,7 +36,7 @@
 #'   get_layers(fserv, name = c("Tracts", "ZCTAs"))
 #'   get_all_layers(fserv)
 #' }
-get_layer <- function(x, id = NULL, name = NULL, token = Sys.getenv("ARCGIS_TOKEN")) {
+get_layer <- function(x, id = NULL, name = NULL, token = arc_token()) {
   # check for mutual exclusivity between id and name
   if (is.null(id) && is.null(name)) {
     cli::cli_abort("{.arg id} or {.arg name} must be provided.")
@@ -55,7 +55,7 @@ get_layer <- function(x, id = NULL, name = NULL, token = Sys.getenv("ARCGIS_TOKE
 }
 
 #' @export
-get_layer.default <- function(x, id = NULL, name = NULL, token = Sys.getenv("ARCGIS_TOKEN")) {
+get_layer.default <- function(x, id = NULL, name = NULL, token = arc_token()) {
 
   if (!is.null(name)) {
 
@@ -104,7 +104,7 @@ get_layer.GroupLayer <- function(
     x,
     id = NULL,
     name = NULL,
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
   if (!is.null(name)) {
 
@@ -148,12 +148,12 @@ get_layer.GroupLayer <- function(
 
 #' @rdname get_layer
 #' @export
-get_all_layers <- function(x, token = Sys.getenv("ARCGIS_TOKEN")) {
+get_all_layers <- function(x, token = arc_token()) {
   UseMethod("get_all_layers")
 }
 
 #' @export
-get_all_layers.default <- function(x, token = Sys.getenv("ARCGIS_TOKEN")) {
+get_all_layers.default <- function(x, token = arc_token()) {
   layer_ids <- x[["layers"]][["id"]]
   table_ids <- x[["tables"]][["id"]]
   layers <- lapply(file.path(x[["url"]], layer_ids), arc_open, token = token)
@@ -168,7 +168,7 @@ get_all_layers.default <- function(x, token = Sys.getenv("ARCGIS_TOKEN")) {
 }
 
 #' @export
-get_all_layers.GroupLayer <- function(x, token = Sys.getenv("ARCGIS_TOKEN")) {
+get_all_layers.GroupLayer <- function(x, token = arc_token()) {
   all_layer_ids <- x[["subLayers"]][["id"]]
 
   all_layer_paths <- vapply(
@@ -187,7 +187,7 @@ get_layers <- function(
     x,
     id = NULL,
     name = NULL,
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
   if (is.null(id) && is.null(name)) {
     cli::cli_abort("{.arg id} or {.arg name} must be provided.")
@@ -204,7 +204,7 @@ get_layers <- function(
 }
 
 #' @export
-get_layers.default <- function(x, id = NULL, name = NULL, token = Sys.getenv("ARCGIS_TOKEN")) {
+get_layers.default <- function(x, id = NULL, name = NULL, token = arc_token()) {
 
   if (!is.null(id)) {
     # cast as integer
@@ -260,7 +260,7 @@ get_layers.GroupLayer <- function(
     x,
     id = NULL,
     name = NULL,
-    token = Sys.getenv("ARCGIS_TOKEN")
+    token = arc_token()
 ) {
   if (!is.null(id)) {
     # cast as integer

--- a/man/arc_open.Rd
+++ b/man/arc_open.Rd
@@ -4,7 +4,7 @@
 \alias{arc_open}
 \title{Open connection to remote resource}
 \usage{
-arc_open(url, token = Sys.getenv("ARCGIS_TOKEN"))
+arc_open(url, token = arc_token())
 }
 \arguments{
 \item{url}{The url of the remote resource. Must be of length one.}

--- a/man/arc_raster.Rd
+++ b/man/arc_raster.Rd
@@ -15,7 +15,7 @@ arc_raster(
   width = NULL,
   height = NULL,
   format = "tiff",
-  token = Sys.getenv("ARCGIS_TOKEN")
+  token = arc_token()
 )
 }
 \arguments{

--- a/man/arc_read.Rd
+++ b/man/arc_read.Rd
@@ -13,7 +13,7 @@ arc_read(
   crs = NULL,
   ...,
   fields = NULL,
-  token = Sys.getenv("ARCGIS_TOKEN")
+  token = arc_token()
 )
 }
 \arguments{

--- a/man/arc_select.Rd
+++ b/man/arc_select.Rd
@@ -13,7 +13,7 @@ arc_select(
   filter_geom = NULL,
   predicate = "intersects",
   n_max = Inf,
-  token = Sys.getenv("ARCGIS_TOKEN"),
+  token = arc_token(),
   ...
 )
 }

--- a/man/create_feature_server.Rd
+++ b/man/create_feature_server.Rd
@@ -19,7 +19,7 @@ create_feature_server(
   has_static_data = FALSE,
   xss_prevention = xss_defaults(),
   host = arc_host(),
-  token = Sys.getenv("ARCGIS_TOKEN")
+  token = arc_token()
 )
 
 xss_defaults()

--- a/man/get_layer.Rd
+++ b/man/get_layer.Rd
@@ -6,11 +6,11 @@
 \alias{get_layers}
 \title{Extract a layer from a Feature or Map Server}
 \usage{
-get_layer(x, id = NULL, name = NULL, token = Sys.getenv("ARCGIS_TOKEN"))
+get_layer(x, id = NULL, name = NULL, token = arc_token())
 
-get_all_layers(x, token = Sys.getenv("ARCGIS_TOKEN"))
+get_all_layers(x, token = arc_token())
 
-get_layers(x, id = NULL, name = NULL, token = Sys.getenv("ARCGIS_TOKEN"))
+get_layers(x, id = NULL, name = NULL, token = arc_token())
 }
 \arguments{
 \item{x}{an object of class \code{FeatureServer} or \code{MapServer}}

--- a/man/get_layer_estimates.Rd
+++ b/man/get_layer_estimates.Rd
@@ -4,7 +4,7 @@
 \alias{get_layer_estimates}
 \title{Get Estimates}
 \usage{
-get_layer_estimates(x, token = Sys.getenv("ARCGIS_TOKEN"))
+get_layer_estimates(x, token = arc_token())
 }
 \arguments{
 \item{x}{an object of class \code{FeatureLayer}, \code{Table}, or \code{ImageServer}.}

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -12,14 +12,14 @@ add_features(
   chunk_size = 2000,
   match_on = c("name", "alias"),
   rollback_on_failure = TRUE,
-  token = Sys.getenv("ARCGIS_TOKEN")
+  token = arc_token()
 )
 
 update_features(
   x,
   .data,
   match_on = c("name", "alias"),
-  token = Sys.getenv("ARCGIS_TOKEN"),
+  token = arc_token(),
   rollback_on_failure = TRUE,
   ...
 )
@@ -31,7 +31,7 @@ delete_features(
   filter_geom = NULL,
   predicate = "intersects",
   rollback_on_failure = TRUE,
-  token = Sys.getenv("ARCGIS_TOKEN"),
+  token = arc_token(),
   ...
 )
 }

--- a/man/publish.Rd
+++ b/man/publish.Rd
@@ -18,7 +18,7 @@ add_item(
   async = FALSE,
   type = "Feature Service",
   host = arc_host(),
-  token = Sys.getenv("ARCGIS_TOKEN")
+  token = arc_token()
 )
 
 publish_item(
@@ -27,7 +27,7 @@ publish_item(
   publish_params = .publish_params(),
   file_type = "featureCollection",
   host = arc_host(),
-  token = Sys.getenv("ARCGIS_TOKEN")
+  token = arc_token()
 )
 
 publish_layer(
@@ -37,7 +37,7 @@ publish_layer(
   user = Sys.getenv("ARCGIS_USER"),
   publish_params = .publish_params(title, target_crs = sf::st_crs(x)),
   host = arc_host(),
-  token = Sys.getenv("ARCGIS_TOKEN")
+  token = arc_token()
 )
 
 .publish_params(

--- a/man/truncate_layer.Rd
+++ b/man/truncate_layer.Rd
@@ -4,12 +4,7 @@
 \alias{truncate_layer}
 \title{Truncate a Feature Layer}
 \usage{
-truncate_layer(
-  x,
-  async = FALSE,
-  attachment_only = FALSE,
-  token = Sys.getenv("ARCGIS_TOKEN")
-)
+truncate_layer(x, async = FALSE, attachment_only = FALSE, token = arc_token())
 }
 \arguments{
 \item{x}{an object of class \code{FeatureLayer}, \code{Table}, or \code{ImageServer}.}


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

When "ARCGIS_TOKEN" is an empty string, it will sometimes cause HTTP 498 "invalid token" error. Need to NULL the empty string to handle this. 

**Issues that this closes** 

No issue opened here. See https://github.com/R-ArcGIS/arcgisutils/issues/5.

## Follow up tasks

Waiting for https://github.com/R-ArcGIS/arcgisutils/pull/6 to be merged first.
