### PR TITLE
remove user argument. Use arcgisutils check_token_has_user()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - **Breaking**: 
   - `token` arguments are required to be a valid `httr2_token` object (strings are not supported).
   - all `host` arguments are removed. Instead, the host is fetched from the `token`.
+  - all `user` arguments are removed. Instead, the username is fetched from the `token`. If it is not found, an error is thrown.
 - Add support for `GroupLayer`s
 - Add `arc_read()` with support for `name_repair` argument using `{vctrs}` (#108)
 - Add `get_layer_estimates()` to retrieve estimate info such as the number of features and the extent of the layer

--- a/R/add_item.R
+++ b/R/add_item.R
@@ -61,7 +61,6 @@
 add_item <- function(
     x,
     title,
-    user = Sys.getenv("ARCGIS_USER"),
     description = "",
     tags = character(0),
     snippet = "",
@@ -74,6 +73,12 @@ add_item <- function(
 
   # validate the token
   obj_check_token(token)
+
+  # check that there is a user associated with the token
+  check_token_has_user(token)
+
+  # extract username
+  user <- token[["username"]]
 
   # fetch the host from the token
   host <- token[["arcgis_host"]]
@@ -175,7 +180,6 @@ add_item <- function(
 #' @rdname publish
 publish_item <- function(
     item_id,
-    user = Sys.getenv("ARCGIS_USER"),
     publish_params = .publish_params(),
     file_type = "featureCollection",
     token = arc_token()
@@ -183,6 +187,12 @@ publish_item <- function(
 
   # validate the token
   obj_check_token(token)
+
+  # check that there is a user associated with the token
+  check_token_has_user(token)
+
+  # extract username
+  user <- token[["username"]]
 
   # fetch the host
   host <- token[["arcgis_host"]]
@@ -221,7 +231,6 @@ publish_layer <- function(
     x,
     title,
     ...,
-    user = Sys.getenv("ARCGIS_USER"),
     publish_params = .publish_params(title, target_crs = sf::st_crs(x)),
     token = arc_token()
 ) {
@@ -232,7 +241,6 @@ publish_layer <- function(
     add_item(
       x,
       title,
-      user = user,
       token = token,
       !!!adtl_args
     )
@@ -244,7 +252,6 @@ publish_layer <- function(
 
   published_item <- publish_item(
     item_id,
-    user = user,
     publish_params = publish_params,
     token = token
   )

--- a/R/add_item.R
+++ b/R/add_item.R
@@ -32,8 +32,6 @@
 #' `add_item()`.
 #'
 #' @inheritParams arcgisutils::as_layer
-#' @param user default environment variable `Sys.getenv("ARCGIS_USER")`.
-#'   The username to publish the item under.
 #' @param description a length 1 character vector containing the description of
 #'   the item that is being added. Note that the value cannot be larger than 64kb.
 #' @param tags a character vector of tags to add to the item.

--- a/R/create-service.R
+++ b/R/create-service.R
@@ -30,13 +30,12 @@
 #'
 #' @export
 #' @examples
-#' if (interactive()) {
+#' \donttest{
 #'   set_arc_token(auth_code())
 #'   create_feature_server("My empty feature server")
 #' }
 create_feature_server <- function(
     service_name,
-    user = Sys.getenv("ARCGIS_USER"),
     description = "",
     crs = 3857,
     capabilities = c("create", "delete", "query", "update", "editing"),
@@ -56,6 +55,12 @@ create_feature_server <- function(
 
   # validate the token
   obj_check_token(token)
+
+  # check that there is a user associated with the token
+  check_token_has_user(token)
+
+  # extract username
+  user <- token[["username"]]
 
   # fetch the host
   host <- token[["arcgis_host"]]

--- a/R/create-service.R
+++ b/R/create-service.R
@@ -30,8 +30,10 @@
 #' @export
 #' @examples
 #' \donttest{
+#' if (interactive()) {
 #'   set_arc_token(auth_code())
 #'   create_feature_server("My empty feature server")
+#' }
 #' }
 create_feature_server <- function(
     service_name,

--- a/R/create-service.R
+++ b/R/create-service.R
@@ -3,7 +3,6 @@
 #' Creates an empty FeatureServer with no additional layers.
 #'
 #' @param service_name Feature Service name.
-#' @param user default `Sys.getenv("ARCGIS_USER")`. Your account's username.
 #' @param description default blank. The description of the feature server.
 #' @param crs default `3857`. A coordinate reference system to set for the feature server.
 #'  Must be compatible with `sf::st_crs()`.

--- a/man/create_feature_server.Rd
+++ b/man/create_feature_server.Rd
@@ -50,8 +50,6 @@ retrieved from a layer in one request.}
 See details for more.}
 
 \item{token}{an \code{httr2_token} as created by \code{auth_code()} or similar}
-
-\item{user}{default \code{Sys.getenv("ARCGIS_USER")}. Your account's username.}
 }
 \value{
 If a \code{FeatureServer} is created successfully, a \code{FeatureServer} object is returned

--- a/man/create_feature_server.Rd
+++ b/man/create_feature_server.Rd
@@ -63,7 +63,9 @@ Creates an empty FeatureServer with no additional layers.
 }
 \examples{
 \donttest{
+if (interactive()) {
   set_arc_token(auth_code())
   create_feature_server("My empty feature server")
+}
 }
 }

--- a/man/create_feature_server.Rd
+++ b/man/create_feature_server.Rd
@@ -7,7 +7,6 @@
 \usage{
 create_feature_server(
   service_name,
-  user = Sys.getenv("ARCGIS_USER"),
   description = "",
   crs = 3857,
   capabilities = c("create", "delete", "query", "update", "editing"),
@@ -25,8 +24,6 @@ xss_defaults()
 }
 \arguments{
 \item{service_name}{Feature Service name.}
-
-\item{user}{default \code{Sys.getenv("ARCGIS_USER")}. Your account's username.}
 
 \item{description}{default blank. The description of the feature server.}
 
@@ -53,6 +50,8 @@ retrieved from a layer in one request.}
 See details for more.}
 
 \item{token}{an \code{httr2_token} as created by \code{auth_code()} or similar}
+
+\item{user}{default \code{Sys.getenv("ARCGIS_USER")}. Your account's username.}
 }
 \value{
 If a \code{FeatureServer} is created successfully, a \code{FeatureServer} object is returned
@@ -65,7 +64,7 @@ Creates an empty FeatureServer with no additional layers.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 }
 \examples{
-if (interactive()) {
+\donttest{
   set_arc_token(auth_code())
   create_feature_server("My empty feature server")
 }

--- a/man/publish.Rd
+++ b/man/publish.Rd
@@ -83,9 +83,6 @@ add to the published Feature Service.}
 
 \item{max_record_count}{the maximum number of records that can be returned
 from the created Feature Service.}
-
-\item{user}{default environment variable \code{Sys.getenv("ARCGIS_USER")}.
-The username to publish the item under.}
 }
 \value{
 A named list containing the url of the newly published service.

--- a/man/publish.Rd
+++ b/man/publish.Rd
@@ -10,7 +10,6 @@
 add_item(
   x,
   title,
-  user = Sys.getenv("ARCGIS_USER"),
   description = "",
   tags = character(0),
   snippet = "",
@@ -22,7 +21,6 @@ add_item(
 
 publish_item(
   item_id,
-  user = Sys.getenv("ARCGIS_USER"),
   publish_params = .publish_params(),
   file_type = "featureCollection",
   token = arc_token()
@@ -32,7 +30,6 @@ publish_layer(
   x,
   title,
   ...,
-  user = Sys.getenv("ARCGIS_USER"),
   publish_params = .publish_params(title, target_crs = sf::st_crs(x)),
   token = arc_token()
 )
@@ -51,9 +48,6 @@ any other subclass of \code{data.frame}.}
 
 \item{title}{A user-friendly string title for the layer that can be used in
 a table of contents.}
-
-\item{user}{default environment variable \code{Sys.getenv("ARCGIS_USER")}.
-The username to publish the item under.}
 
 \item{description}{a length 1 character vector containing the description of
 the item that is being added. Note that the value cannot be larger than 64kb.}
@@ -89,6 +83,9 @@ add to the published Feature Service.}
 
 \item{max_record_count}{the maximum number of records that can be returned
 from the created Feature Service.}
+
+\item{user}{default environment variable \code{Sys.getenv("ARCGIS_USER")}.
+The username to publish the item under.}
 }
 \value{
 A named list containing the url of the newly published service.


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

This PR removes the `user` arguments from publishing functions. The user is now fetched from the auth token. 

## Follow up tasks

- [ ] revist r.esri.com authorization document