### PR TITLE
Add `page_size` argument to `arc_select()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,6 @@
 # arcgislayers 0.1.0 (unreleased)
 
-- **Breaking**: 
-  - `token` arguments are required to be a valid `httr2_token` object (strings are not supported).
-  - all `host` arguments are removed. Instead, the host is fetched from the `token`.
-  - all `user` arguments are removed. Instead, the username is fetched from the `token`. If it is not found, an error is thrown.
+- includes `page_size` argument to `arc_select()` allowing users to return smaller page sizes and avoid timeouts for dense geometries
 - Add support for `GroupLayer`s
 - Add `arc_read()` with support for `name_repair` argument using `{vctrs}` (#108)
 - Add `get_layer_estimates()` to retrieve estimate info such as the number of features and the extent of the layer
@@ -18,3 +15,8 @@
 - adds cli as an explicit import (has been implicitly imported by httr2)
 - repository made public
 - add lifecycle badges to all exported functions <https://github.com/R-ArcGIS/arcgislayers/pull/101>
+
+- **Breaking**: 
+  - `token` arguments are required to be a valid `httr2_token` object (strings are not supported).
+  - all `host` arguments are removed. Instead, the host is fetched from the `token`.
+  - all `user` arguments are removed. Instead, the username is fetched from the `token`. If it is not found, an error is thrown.

--- a/man/arc_select.Rd
+++ b/man/arc_select.Rd
@@ -13,6 +13,7 @@ arc_select(
   filter_geom = NULL,
   predicate = "intersects",
   n_max = Inf,
+  page_size = NULL,
   token = arc_token(),
   ...
 )
@@ -43,6 +44,8 @@ query results based on a predicate function.}
 \item{n_max}{the maximum number of features to return. By default returns
 every feature available. Unused at the moment.}
 
+\item{page_size}{the maximum number of features to return per request. See Details.}
+
 \item{token}{your authorization token. By default checks the environment
 variable \code{ARCGIS_TOKEN}. Set your token using \code{arcgisutils::set_auth_token()}.}
 
@@ -57,6 +60,19 @@ the layer as an \code{sf} object or \code{tibble} respectively.
 }
 \details{
 See \href{https://developers.arcgis.com/rest/services-reference/enterprise/query-feature-service-layer-.htm#GUID-BC2AD141-3386-49FB-AA09-FF341145F614}{reference documentation} for possible arguments.
+
+\code{FeatureLayers} can contain very dense geometries with a lot of coordinates.
+In those cases, the feature service may time out before all geometries can
+be returned. To address this issue, we can reduce the number of features
+returned per each request by reducing the value of the \code{page_size} parameter.
+
+\code{arc_select()} works by sending a single request that counts the number of
+features that will be returned by the current query. That number is then used
+to calculate how many "pages" of responses are needed to fetch all the results.
+The number of features returned (page size) is set to the \code{maxRecordCount}
+property of the layer by default. However, by setting \code{page_size} to be
+smaller than the \code{maxRecordCount} we can return fewer geometries per page and
+avoid time outs.
 
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 }

--- a/tests/testthat/test-arc_select.R
+++ b/tests/testthat/test-arc_select.R
@@ -25,3 +25,24 @@ test_that("arc_select() works on `ImageServer`s", {
   tmp <- arc_select(landsat, n_max = 2, where = "Month = 2")
   expect_snapshot(tmp)
 })
+
+
+test_that("arc_select(): respects `n_max`", {
+  furl <- "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/PLACES_LocalData_for_BetterHealth/FeatureServer/0"
+
+  flayer <- arc_open(furl)
+
+  res <- arc_select(flayer, n_max = 999)
+
+  expect_identical(nrow(res), 999L)
+})
+
+test_that("arc_select(): respects `n_max` & `page_size`", {
+  furl <- "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/PLACES_LocalData_for_BetterHealth/FeatureServer/0"
+
+  flayer <- arc_open(furl)
+
+  res <- arc_select(flayer, n_max = 999, page_size = 111)
+
+  expect_identical(nrow(res), 999L)
+})


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

This PR adds a `page_size` argument to `arc_select()` which permits us to have more control over the total number of features that are returned on a per-request basis. This will allow us to overcome the issue of timeouts with dense geometries. 

## Closes 

- closes https://github.com/R-ArcGIS/arcgislayers/issues/141

## Follow up tasks

- Create docs on working with dense geometries. This doc will tell users how to utilize the `batch_size` argument to increase the number of requests made and reduce the number of features per page.
