### PR TITLE
fix: get_layers() did not work on tables

### DIFF
--- a/R/utils-feature-server.R
+++ b/R/utils-feature-server.R
@@ -211,7 +211,7 @@ get_layers.default <- function(x, id = NULL, name = NULL, token = arc_token()) {
     id <- as.integer(id)
 
     # ensure that all elements of `id` are in the layers
-    in_ids <- id %in% x[["layers"]][["id"]]
+    in_ids <- id %in% c(x[["layers"]][["id"]], x[["tables"]][["id"]])
 
     # if not report and remove
     baddies <- id[!in_ids]
@@ -223,7 +223,7 @@ get_layers.default <- function(x, id = NULL, name = NULL, token = arc_token()) {
     id <- id[in_ids]
     item_urls <- file.path(x[["url"]], id)
   } else if (!is.null(name)) {
-    valid_names <- x[["layers"]][["name"]]
+    valid_names <- c(x[["layers"]][["name"]], x[["tables"]][["name"]])
 
     # validate names
     in_names <- name %in% valid_names
@@ -234,7 +234,7 @@ get_layers.default <- function(x, id = NULL, name = NULL, token = arc_token()) {
     }
 
     # create lookup table for fetching ids
-    lu <- stats::setNames(x[["layers"]][["id"]], valid_names)
+    lu <- stats::setNames(c(x[["layers"]][["id"]], x[["tables"]][["id"]]), valid_names)
 
     item_urls <- file.path(
       x[["url"]],

--- a/tests/testthat/_snaps/get-layers.md
+++ b/tests/testthat/_snaps/get-layers.md
@@ -118,3 +118,14 @@
       Capabilities: Map,Query,Data
       
 
+# get_layers(): can fetch Table
+
+    Code
+      get_layers(fsrv, 1)
+    Output
+      [[1]]
+      <Table>
+      Name: Pop_Up_Table
+      Capabilities: Query,Extract,Sync
+      
+

--- a/tests/testthat/test-get-layers.R
+++ b/tests/testthat/test-get-layers.R
@@ -53,3 +53,11 @@ test_that("get_layers(): GroupLayer name", {
     get_layers(glyr, name = c("Bus Stops", "Bus Routes"))
   )
 })
+
+
+test_that("get_layers(): can fetch Table", {
+  furl <- "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Wetlands/FeatureServer"
+  fsrv <- arc_open(furl)
+
+  expect_snapshot(get_layers(fsrv, 1))
+})


### PR DESCRIPTION
## Changes 

This PR fixes a bug where `get_layers()` would not work on `Table`s in a `FeatureServer`

**Issues that this closes** 

closes https://github.com/R-ArcGIS/arcgislayers/issues/147
