### PR TITLE
remove compact() from arc_open()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # arcgislayers 0.1.0 (unreleased)
 
+- `arc_open()` no longer removes `NULL` properties h/t [@elipousson](https://github.com/elipousson)
 - includes `page_size` argument to `arc_select()` allowing users to return smaller page sizes and avoid timeouts for dense geometries
 - Add support for `GroupLayer`s
 - Add `arc_read()` with support for `name_repair` argument using `{vctrs}` (#108)

--- a/R/arc-open.R
+++ b/R/arc-open.R
@@ -61,7 +61,7 @@ arc_open <- function(url, token = arc_token()) {
   check_url(url)
 
   # extract layer metadata
-  meta <- compact(fetch_layer_metadata(url, token))
+  meta <- fetch_layer_metadata(url, token)
 
   # set url for later use
   meta[["url"]] <- url

--- a/tests/testthat/test-arc_open.R
+++ b/tests/testthat/test-arc_open.R
@@ -43,7 +43,11 @@ test_that("arc_open(): GroupLayer", {
   expect_no_error(arc_open(gurl))
 })
 
+test_that("arc_open(): doesn't filter NULL properties", {
 
+  furl <- "https://geodata.md.gov/imap/rest/services/Transportation/MD_Transit/FeatureServer/8"
 
+  flayer <- arc_open(furl)
 
-
+  expect_identical(length(flayer), 56L)
+})


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

Per request of @elipousson, remove `compact()` around `fetch_layer_metadata()` so that all properties, including NULL ones, are returned from `arc_open()`. 

``` r
library(arcgislayers)

"https://geodata.md.gov/imap/rest/services/Transportation/MD_Transit/FeatureServer/1" |> 
  arc_open() |> 
  length()
#> [1] 56

"https://geodata.md.gov/imap/rest/services/Transportation/MD_Transit/FeatureServer/9" |> 
  arc_open() |> 
  length()
#> [1] 56
```