### PR TITLE
fix arc_raster

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # arcgislayers (development)
 
+- `arc_raster()` now downloads the exported image to a temp file instead of creating a connection to the url returned. This fixes an issue where rasters would stop working after the url had been removed. 
 - Add `alias` argument to `arc_read()` allowing replacement or labelling of field names with alias values (#169)
 - Add `pull_field_aliases()` utility function
 - `arc_select()` now uses `arcgisutils::rbind_results()` for faster row-binding if `{collapse}`, `{data.table}`, `{vctrs}` are installed (#175)

--- a/R/arc-raster.R
+++ b/R/arc-raster.R
@@ -54,10 +54,7 @@ arc_raster <- function(
     width = NULL,
     height = NULL,
     format = "tiff",
-    token = arc_token()
-) {
-
-
+    token = arc_token()) {
   # validate and extract CRS object
   out_sr <- validate_crs(crs)[["spatialReference"]][["wkid"]]
 
@@ -82,16 +79,18 @@ arc_raster <- function(
 
   # fetch the response
   resp <- httr2::req_perform(req)
-
   resp_meta <- RcppSimdJson::fparse(httr2::resp_body_string(resp))
 
   detect_errors(resp_meta)
 
+  tmp <- tempfile(fileext = paste0(".", format))
+  exported_image_path <- resp_meta[["href"]]
+  utils::download.file(exported_image_path, tmp, quiet = TRUE)
+
   res <- terra::rast(
-    resp_meta$href
+    tmp
   )
 
   names(res) <- x[["bandNames"]]
   res
-
 }


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

This modifies `arc_raster()` so that the result of `/exportImage` is downloaded into a temporary file fixing issues where the url would expire after connecting to it.