### PR TITLE
Fix #185

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Add `alias` argument to `arc_read()` allowing replacement or labelling of field names with alias values (#169)
 - Add `pull_field_aliases()` utility function
 - `arc_select()` now uses `arcgisutils::rbind_results()` for faster row-binding if `{collapse}`, `{data.table}`, `{vctrs}` are installed (#175)
+- Preserve order of `fields` column names for `arc_select()` (fixes minor bug with `arc_read` handling of `col_names`) (#185)
 
 # arcgislayers 0.2.0
 

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -248,8 +248,8 @@ collect_layer <- function(
   # selected
   if (rlang::is_named(res) && has_out_fields) {
     out_fields <- c(out_fields, attr(res, "sf_column"))
-    res_nm <- names(res)
-    res <- res[, tolower(res_nm) %in% tolower(out_fields), drop = FALSE]
+    match_nm <- match(tolower(out_fields), tolower(names(res)))
+    res <- res[, match_nm[!is.na(match_nm)], drop = FALSE]
   }
 
   if (rlang::is_empty(res)) {


### PR DESCRIPTION
## Checklist 

- [X] update NEWS.md
- [X] `devtools::check()` passes locally

## Changes 

Modify handling of matching between input fields parameter (if supplied) and the results name values to ensure that the column name order supplied to fields (or col_names by arc_read) is respected.

**Issues that this closes** 

https://github.com/R-ArcGIS/arcgislayers/issues/185