### PR TITLE
Fix #191 and #188

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 - Add `pull_field_aliases()` utility function
 - `arc_select()` now uses `arcgisutils::rbind_results()` for faster row-binding if `{collapse}`, `{data.table}`, `{vctrs}` are installed (#175)
 - Preserve order of `fields` column names for `arc_select()` (fixes minor bug with `arc_read` handling of `col_names`) (#185)
+- Set CRS for a FeatureLayer or ImageServer using `"wkid"` or `"wkt"` value if `"latestWkid"` is missing. (#188)
+- Fix issue with `arc_select()` when layer can't support pagination. (#191)
 
 # arcgislayers 0.2.0
 

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -269,8 +269,12 @@ get_query_resps <- function(req,
   if (isFALSE(x[["advancedQueryCapabilities"]][["supportsPagination"]])) {
     if (n_feats > x[["maxRecordCount"]]) {
       cli::cli_warn(
-        "query can't return complete results if {class(x)} does not support pagination
-        and the number of selected features exceeds the maximum record count."
+        c(
+          "{class(x)} {.val {x[['name']]}} does not support pagination and
+          complete results can't be returned.",
+          "i" = "{n_feats} features are selected by the query and the maximum
+          is {x[['maxRecordCount']]} records."
+        )
       )
     }
 

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -156,7 +156,6 @@ collect_layer <- function(
     page_size = NULL,
     ...,
     error_call = rlang::caller_env()) {
-
   # 1. Make base request
   # 2. Identify necessary query parameters
   # 3. Figure out offsets and update query parameters
@@ -260,12 +259,17 @@ collect_layer <- function(
 
 #' Get query responses with handling for layers that don't support pagination
 #' @noRd
-get_query_resps <- function(req,
-                            x,
-                            n_feats,
-                            page_size = NULL,
-                            query_params = list(),
-                            error_call = rlang::caller_env()) {
+get_query_resps <- function(
+    req,
+    x,
+    n_feats,
+    page_size = NULL,
+    query_params = list(),
+    error_call = rlang::caller_env()) {
+  # If pagination is not supported, we create one query and return the results
+  # in a list with a warning. This way the maximum number of results is returned
+  # but the user is also informed that they will not get tha maximum number of
+  # records. Otherwise, we continue and utilize the pagination
   if (isFALSE(x[["advancedQueryCapabilities"]][["supportsPagination"]])) {
     if (n_feats > x[["maxRecordCount"]]) {
       cli::cli_warn(
@@ -470,8 +474,7 @@ count_results <- function(req, query, n_max = Inf, error_call = rlang::caller_en
 validate_results_count <- function(
     n_results = NULL,
     n_max = Inf,
-    error_call = rlang::caller_env()
-) {
+    error_call = rlang::caller_env()) {
   if (is.null(n_results)) {
     cli::cli_abort(
       c(

--- a/R/sf-methods.R
+++ b/R/sf-methods.R
@@ -1,11 +1,22 @@
-
 # st_crs method for feature layer
 st_crs.FeatureLayer <- function(obj, ...) {
-  sf::st_crs(obj[["extent"]][["spatialReference"]][["latestWkid"]])
+  spatialReference <- obj[["extent"]][["spatialReference"]]
+
+  obj_crs <- spatialReference[["latestWkid"]] %||%
+    spatialReference[["wkid"]] %||%
+    spatialReference[["wkt"]]
+
+  sf::st_crs(obj_crs)
 }
 
 st_crs.ImageServer <- function(obj, ...) {
-  sf::st_crs(obj[["extent"]][["spatialReference"]][["latestWkid"]])
+  spatialReference <- obj[["extent"]][["spatialReference"]]
+
+  obj_crs <- spatialReference[["latestWkid"]] %||%
+    spatialReference[["wkid"]] %||%
+    spatialReference[["wkt"]]
+
+  sf::st_crs(obj_crs)
 }
 
 

--- a/R/sf-methods.R
+++ b/R/sf-methods.R
@@ -1,23 +1,36 @@
 # st_crs method for feature layer
 st_crs.FeatureLayer <- function(obj, ...) {
-  spatialReference <- obj[["extent"]][["spatialReference"]]
-
-  obj_crs <- spatialReference[["latestWkid"]] %||%
-    spatialReference[["wkid"]] %||%
-    spatialReference[["wkt"]]
-
-  sf::st_crs(obj_crs)
+  arc_sr_as_crs(obj)
 }
 
 st_crs.ImageServer <- function(obj, ...) {
-  spatialReference <- obj[["extent"]][["spatialReference"]]
+  arc_sr_as_crs(obj)
+}
 
-  obj_crs <- spatialReference[["latestWkid"]] %||%
+#' Get a Coordinate Reference System from a FeatureLayer or ImageServer spatial
+#' reference
+#'
+#' [arc_sr_as_crs()] converts a FeatureLayer or ImageServer into a coordinate
+#' reference system (CRS) using [sf::st_crs()].
+#'
+#' @param x A FeatureLayer or ImageServer or another object with a named
+#'   `"spatialReference"` element that can be converted to a coordinate
+#'   reference system with [sf::st_crs()].
+#' @seealso [arcgisutils::validate_crs()]
+#' @returns An object of class crs of length 2.
+#' @noRd
+arc_sr_as_crs <- function(x) {
+  if (rlang::has_name(x, "extent")) {
+    spatialReference <- x[["extent"]][["spatialReference"]]
+  } else {
+    spatialReference <- x[["spatialReference"]] %||% list()
+  }
+
+  x_crs <- spatialReference[["latestWkid"]] %||%
     spatialReference[["wkid"]] %||%
     spatialReference[["wkt"]]
 
-  sf::st_crs(obj_crs)
+  sf::st_crs(x_crs)
 }
-
 
 # Implement `st_transform()`


### PR DESCRIPTION
## Checklist 

- [X] update NEWS.md
- [X] documentation updated with `devtools::document()`
- [-] `devtools::check()` passes locally

## Changes 

Fixes  #191 by adding a helper function (`get_query_resps()`) that handles layers that don't support pagination by using a standard query request.

Also fixes the CRS bug #188 using a similar approach as the esri2sf package.

**Issues that this closes** 

Fix #191 and #188

## Follow up tasks

None identified.