### PR TITLE
Bug fix: page_size was not respected 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: arcgislayers
 Type: Package
 Title: An Interface to ArcGIS Data Services
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: c(
     person("Josiah", "Parry", , "josiah.parry@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9910-865X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# arcgislayers (development version)
+
+## Bug fixes
+
+- `page_size` resulted in error due to introduction of type-check. Fixed and added test to avoid in the future.  [#205](https://github.com/R-ArcGIS/arcgislayers/issues/205)
+
+## New features
+
+## Breaking changes 
+
 # arcgislayers 0.3.0
 
 - `arc_open()` will now work on any resource that works when `f=json` is set in the query parameters closes [#163](https://github.com/R-ArcGIS/arcgislayers/issues/163)

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -85,7 +85,17 @@ arc_select <- function(
   check_number_whole(n_max, min = 0, allow_infinite = TRUE)
   check_string(where, allow_null = TRUE, allow_empty = FALSE)
   check_character(fields, allow_null = TRUE)
-  check_number_whole(page_size, min = 1, max = x[["maxRecordCount"]], allow_null = TRUE)
+
+
+  check_number_whole(as.integer(page_size), min = 1, allow_null = TRUE)
+  check_number_whole(
+    as.integer(page_size),
+    # bug in the standalone checks
+    # needs to be a double and cannot be used with
+    # max at the same time which is why it is brought into two calls
+    max = as.double(x[["maxRecordCount"]]),
+    allow_null = TRUE
+  )
 
   # extract the query object
   query <- attr(x, "query")

--- a/tests/testthat/test-page-size.R
+++ b/tests/testthat/test-page-size.R
@@ -1,0 +1,6 @@
+test_that("multiplication works", {
+  furl <- "https://services.arcgis.com/GL0fWlNkwysZaKeV/arcgis/rest/services/TXLA_ZCTA_PRCPpred/FeatureServer/0"
+
+  layer <- arc_open(furl)
+  expect_no_error(arc_select(layer, n_max = 10, page_size = 2))
+})


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

This PR modifies the type checks use in `arc_select()` when `page_size` argument was passed.

There was no test to check that this feature worked which is why the change wasn't caught. 

This PR adds a test in addition to a fix.


**Issues that this closes** 

#205 

