### PR TITLE
Make attachment metadata optional

### DIFF
--- a/R/attachments.R
+++ b/R/attachments.R
@@ -12,6 +12,7 @@
 #' @param global_ids mutally exclusive with `definition_expression` and `object_ids`. The global IDs of the features to query attachments of.
 #' @param keywords default `NULL`. A character vector of the keywords to filter on.
 #' @param attachment_types default `NULL`. A character vector of attachment types to filter on.
+#' @param return_metadata default `TRUE`. Returns metadata stored in the `exifInfo` field.
 #' @param overwrite default `FALSE`. A
 #' @rdname attachments
 #' @references [ArcGIS REST API Documentation](https://developers.arcgis.com/rest/services-reference/enterprise/query-attachments-feature-service-layer/)
@@ -124,7 +125,6 @@ unnest_attachment_groups <- function(x) {
   )
   data_frame(res)
 }
-
 
 
 # Attachment types

--- a/R/attachments.R
+++ b/R/attachments.R
@@ -49,6 +49,7 @@ query_layer_attachments <- function(
     global_ids = NULL,
     attachment_types = NULL,
     keywords = NULL,
+    return_metadata = TRUE,
     ...,
     token = arc_token()
     # Ignored arguments for now:
@@ -93,7 +94,7 @@ query_layer_attachments <- function(
     attachmentsDefinitionExpression = attachments_definition_expression,
     keywords = keywords,
     returnUrl = TRUE,
-    returnMetadata = TRUE,
+    returnMetadata = return_metadata,
     f = "json"
   )
 

--- a/man/arc_open.Rd
+++ b/man/arc_open.Rd
@@ -25,45 +25,43 @@ To extract data from the remote resource utilize \code{\link[=arc_select]{arc_se
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 }
 \examples{
-
 \dontrun{
- # FeatureLayer
- furl <- paste0(
-   "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/",
-   "PLACES_LocalData_for_BetterHealth/FeatureServer/0"
- )
+# FeatureLayer
+furl <- paste0(
+  "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/",
+  "PLACES_LocalData_for_BetterHealth/FeatureServer/0"
+)
 
- arc_open(furl)
+arc_open(furl)
 
- # Table
- furl <- paste0(
-   "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/",
-   "USA_Wetlands/FeatureServer/1"
- )
+# Table
+furl <- paste0(
+  "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/",
+  "USA_Wetlands/FeatureServer/1"
+)
 
- arc_open(furl)
+arc_open(furl)
 
- # ImageServer
- arc_open(
-   "https://landsat2.arcgis.com/arcgis/rest/services/Landsat/MS/ImageServer"
-   )
+# ImageServer
+arc_open(
+  "https://landsat2.arcgis.com/arcgis/rest/services/Landsat/MS/ImageServer"
+)
 
- # FeatureServer
- furl <- paste0(
-   "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/",
-   "PLACES_LocalData_for_BetterHealth/FeatureServer"
- )
+# FeatureServer
+furl <- paste0(
+  "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/",
+  "PLACES_LocalData_for_BetterHealth/FeatureServer"
+)
 
- arc_open(furl)
+arc_open(furl)
 
- # MapServer
- map_url <- paste0(
-   "https://services.arcgisonline.com/ArcGIS/rest/services/",
-   "World_Imagery/MapServer"
- )
+# MapServer
+map_url <- paste0(
+  "https://services.arcgisonline.com/ArcGIS/rest/services/",
+  "World_Imagery/MapServer"
+)
 
- arc_open(map_url)
-
+arc_open(map_url)
 }
 }
 \seealso{

--- a/man/attachments.Rd
+++ b/man/attachments.Rd
@@ -13,6 +13,7 @@ query_layer_attachments(
   global_ids = NULL,
   attachment_types = NULL,
   keywords = NULL,
+  return_metadata = TRUE,
   ...,
   token = arc_token()
 )
@@ -41,6 +42,8 @@ only attachments that conform to this expression will be returned.}
 \item{attachment_types}{default \code{NULL}. A character vector of attachment types to filter on.}
 
 \item{keywords}{default \code{NULL}. A character vector of the keywords to filter on.}
+
+\item{return_metadata}{default \code{TRUE}. Returns metadata stored in the \code{exifInfo} field.}
 
 \item{...}{unused}
 

--- a/tests/testthat/test-attachments.R
+++ b/tests/testthat/test-attachments.R
@@ -1,0 +1,40 @@
+furl <- "https://services1.arcgis.com/hLJbHVT9ZrDIzK0I/arcgis/rest/services/v8_Wide_Area_Search_Form_Feature_Layer___a2fe9c/FeatureServer/0"
+layer <- arc_open(furl)
+
+test_that("query_layer_attachments() default args", {
+  # connect to the layer
+  expect_no_error()
+})
+
+
+test_that("query_layer_attachments() no metadata", {
+  att <- query_layer_attachments(layer, return_metadata = FALSE)
+  expect_true(all(is.na(att$exifInfo)))
+})
+
+
+test_that("query_layer_attachments() filter on layer field", {
+  att <- query_layer_attachments(layer, "followup_status = 'needs_followup'")
+  expect_equal(nrow(att), 24L)
+})
+
+test_that("query_layer_attachments() filter on attachment field", {
+  att <-
+    query_layer_attachments(
+      layer,
+      attachments_definition_expression = "att_name like 'image0%'"
+    )
+  expect_true(all(grepl("image0*", att$name)))
+})
+
+
+test_that("download_attachments()", {
+  tmp <- tempdir()
+  att <-
+    query_layer_attachments(
+      layer,
+      attachments_definition_expression = "att_name like 'image0%'"
+    )
+  res <- download_attachments(att, tmp)
+  expect_true(all(basename(unlist(res)) %in% list.files(tmp)))
+})


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

This PR adds a new argument to `query_layer_attachments()` which makes returning metadata optional. 

**Issues that this closes** 

This closes #208. This was problematic because the metadata provided from their attachments contains null string characters which are invalid in R. 


