### PR TITLE
use mode="wb" when downloading files

### DIFF
--- a/R/arc-raster.R
+++ b/R/arc-raster.R
@@ -104,7 +104,7 @@ arc_raster <- function(
 
   tmp <- tempfile(fileext = paste0(".", format))
   exported_image_path <- resp_meta[["href"]]
-  utils::download.file(exported_image_path, tmp, quiet = TRUE)
+  utils::download.file(exported_image_path, tmp, quiet = TRUE, mode="wb")
 
   res <- terra::rast(
     tmp


### PR DESCRIPTION
This fixes a bug on windows reported here:  https://github.com/rspatial/terra/issues/1574

From `?donwload.file 

> Code written to download binary files must use mode = "wb" (or "ab"), but the problems incurred by a text transfer will only be seen on Windows.