### PR TITLE
Fix #220 by adding informative warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - `page_size` resulted in error due to introduction of type-check. Fixed and added test to avoid in the future.  [#205](https://github.com/R-ArcGIS/arcgislayers/issues/205)
+- Add warning if `arc_select()` results include fewer features than expected from request [#220](https://github.com/R-ArcGIS/arcgislayers/issues/220)
 
 ## New features
 

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -267,6 +267,17 @@ collect_layer <- function(
     sf::st_crs(res) <- sf::st_crs(x)
   }
 
+  if (nrow(res) < n_feats) {
+    # See https://github.com/R-ArcGIS/arcgislayers/issues/110
+    cli::cli_warn(
+      c(
+        "Results include fewer than the expected {n_feats} features.",
+        "*" = "Try setting {.arg page_size} to a smaller value to make
+        sure results include all available features."
+      )
+    )
+  }
+
   res
 }
 


### PR DESCRIPTION
## Checklist 

- [X] update NEWS.md
- [X] documentation updated with `devtools::document()`
- [X] `devtools::check()` passes locally

## Changes 

Add warning if the number of rows in results is less than the expected number of features.

**Issues that this closes** 

https://github.com/R-ArcGIS/arcgislayers/issues/220

## Follow up tasks

Identify what is causing this issue with the City of Baltimore server so the message can be a bit more specific about trouble-shooting.
