### PR TITLE
Add helper functions to clear default query in URL (#215)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 
 - `arc_raster()` gains an argument `raster_fn` which takes a character scalar and performs a raster function server side before returning results
 - `list_service_raster_fns()` is a new helper function to list available raster functions for an `ImageServer`
+- `arc_open()` ignores default queries included in input URLs and retains custom queries in place of `query` argument. ([#215](https://github.com/R-ArcGIS/arcgislayers/issues/215))
 
 ## Breaking changes 
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 
 - `arc_raster()` gains an argument `raster_fn` which takes a character scalar and performs a raster function server side before returning results
 - `list_service_raster_fns()` is a new helper function to list available raster functions for an `ImageServer`
-- `arc_open()` ignores default queries included in input URLs and retains custom queries in place of `query` argument. ([#215](https://github.com/R-ArcGIS/arcgislayers/issues/215))
+- `arc_open()` ignores queries included in input URLs and retains any custom queries in the `query` attribute for `Table` and `FeatureLayer`s. ([#215](https://github.com/R-ArcGIS/arcgislayers/issues/215))
 
 ## Breaking changes 
 

--- a/R/arc-open.R
+++ b/R/arc-open.R
@@ -57,6 +57,10 @@
 arc_open <- function(url, token = arc_token()) {
   check_url(url)
 
+  # parse url query and strip from url if query matches default
+  query <- parse_url_query(url)
+  url <- clear_url_query(url)
+
   # extract layer metadata
   meta <- fetch_layer_metadata(url, token)
 
@@ -84,12 +88,12 @@ arc_open <- function(url, token = arc_token()) {
     "FeatureLayer" = structure(
       meta,
       class = layer_class,
-      query = list()
+      query = query
     ),
     "Table" = structure(
       meta,
       class = layer_class,
-      query = list()
+      query = query
     ),
     "FeatureServer" = structure(
       meta,

--- a/R/arc-open.R
+++ b/R/arc-open.R
@@ -58,7 +58,7 @@ arc_open <- function(url, token = arc_token()) {
   check_url(url)
 
   # parse url query and strip from url if query matches default
-  query <- parse_url_query(url)
+  query <- parse_url_query(url) %||% list()
   url <- clear_url_query(url)
 
   # extract layer metadata

--- a/R/utils.R
+++ b/R/utils.R
@@ -216,3 +216,50 @@ data_frame <- function(x, call = rlang::caller_env()) {
   check_data_frame(x, call = call)
   structure(x, class = c("tbl", "data.frame"))
 }
+
+#' @noRd
+clear_url_query <- function(url, keep_default = FALSE) {
+  query <- parse_url_query(url, keep_default = keep_default)
+
+  if (rlang::is_empty(query)) {
+    return(url)
+  }
+
+  url_elements <- httr2::url_parse(url)
+
+  # Rebuild URL without query
+  paste0(
+    url_elements[["scheme"]], "://",
+    url_elements[["hostname"]],
+    sub("/query$", "", url_elements[["path"]])
+  )
+}
+
+#' @noRd
+parse_url_query <- function(url, keep_default = FALSE) {
+  # Parse url
+  url_elements <- httr2::url_parse(url)
+
+  # Return empty list if no query is included in url
+  if (is.null(url_elements[["query"]])) {
+    return(list())
+  }
+
+  # Check for default query values
+  query_match <- match(
+    url_elements[["query"]],
+    c(
+      list(outFields = "*", where = "1=1", f = "geojson"),
+      list(outFields = "*", where = "1=1")
+    )
+  )
+
+  # Return empty list for default query
+  if (!is.numeric(query_match) && !keep_default) {
+    invisible(list())
+  }
+
+  # Otherwise return query
+  url_elements[["query"]]
+}
+

--- a/R/utils.R
+++ b/R/utils.R
@@ -221,7 +221,7 @@ data_frame <- function(x, call = rlang::caller_env()) {
 clear_url_query <- function(url, keep_default = FALSE) {
   query <- parse_url_query(url, keep_default = keep_default)
 
-  if (rlang::is_empty(query)) {
+  if (!is.null(query) && rlang::is_empty(query)) {
     return(url)
   }
 
@@ -254,9 +254,9 @@ parse_url_query <- function(url, keep_default = FALSE) {
     )
   )
 
-  # Return empty list for default query
-  if (!is.numeric(query_match) && !keep_default) {
-    invisible(list())
+  # Return NULL for default query
+  if (is.numeric(query_match) && !keep_default) {
+    return(NULL)
   }
 
   # Otherwise return query

--- a/tests/testthat/test-arc_open.R
+++ b/tests/testthat/test-arc_open.R
@@ -4,8 +4,15 @@
 test_that("arc_open(): Feature Layer", {
   ft_url <- "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Counties_Generalized_Boundaries/FeatureServer/0"
 
-  expect_no_error(arc_open(ft_url))
+  lyr <- arc_open(ft_url)
 
+  expect_no_error(lyr)
+
+  ft_query_url <- "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_Counties_Generalized_Boundaries/FeatureServer/0/query?outFields=%2A&where=1%3D1"
+
+  lyr_q <- arc_open(ft_query_url)
+
+  expect_identical(lyr, lyr_q)
 })
 
 


### PR DESCRIPTION
## Checklist 

- [X] update NEWS.md
- [X] documentation updated with `devtools::document()`
- [X] `devtools::check()` passes locally

## Changes 

This is a little different than what you outlined in response to the issue I flagged with #215 but I figured a PR might be the easiest way to show what I had in mind. Basically, the API resource URLs on the standard ArcGIS Hub sites include default query arguments in the URL:

<img width="388" alt="Screenshot 2024-09-26 at 12 25 02 AM" src="https://github.com/user-attachments/assets/38dbb3aa-919a-4215-b302-bf5323a53dcd">

This PR adds utility functions to parse the query, ignore default values, and only retain custom values.

**Issues that this closes** 

https://github.com/R-ArcGIS/arcgislayers/issues/215

## Follow up tasks

Update documentation to show that custom query values are retained but default values are ignored.