### PR TITLE
Improve `arc_select()` error message per #226

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `dplyr` methods for `collect()`, `select()`, and `filter()` have been removed. <https://github.com/R-ArcGIS/arcgislayers/issues/111> <https://github.com/R-ArcGIS/arcgislayers/issues/224> <https://github.com/R-ArcGIS/arcgislayers/issues/218>
 
+## Bug fixes
+
+- `arc_select()` includes argument name in error message when `...` contains non-string values. <https://github.com/R-ArcGIS/arcgislayers/issues/226>
+
 # arcgislayers 0.3.1
 
 ## Bug fixes

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -101,7 +101,7 @@ arc_select <- function(
     key <- dots_names[i]
     val <- dots[[i]]
     # check that the value is a scalar and non-empty
-    check_string(val, allow_empty = FALSE)
+    check_string(val, arg = key, allow_empty = FALSE)
 
     # insert into query
     query[[key]] <- val


### PR DESCRIPTION
## Checklist 

- [X] update NEWS.md
- [X] documentation updated with `devtools::document()`
- [X] `devtools::check()` passes locally

## Changes 

Partly address #226 by passing appropriate value to `arg` parameter of `check_string()` when using `...` with `arc_select()`

## Follow up tasks

The validation of `...` parameters could be improved overall. If `arc_select()` had a `call` argument that would also improve the handling of errors when `arc_select()` is inside of another function (like `arc_read()`).