### PR TITLE
Fill in missing arg for arg_match in `list_field_domains`

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -280,7 +280,7 @@ list_field_domains <- function(x,
   domains <- rlang::set_names(fields[["domain"]], nm)
 
   if (!is.null(field)) {
-    field <- rlang::arg_match(nm, multiple = TRUE, error_call = call)
+    field <- rlang::arg_match(field, nm, multiple = TRUE, error_call = call)
     domains <- domains[nm %in% field]
   }
 


### PR DESCRIPTION
I used `encode_field_values()` with the `field` argument set this evening for the first time and caught what is (in retrospect) an obvious error in the arg_match call used by `list_field_domains()` to validate the input.

## Changes 

Fill in `field` as the `arg` parameter of `rlang::arg_match` within `list_field_domains()`.
