### PR TITLE
Improve handling of missing values for encoded fields

### DIFF
--- a/R/arc-read.R
+++ b/R/arc-read.R
@@ -453,7 +453,9 @@ encode_field_values <- function(
   # Replace column values by default
   if (codes == "replace") {
     for (col in names(values)) {
-      .data[[col]] <- values[[col]][.data[[col]]]
+      replace_val <- values[[col]]
+      miss_val <- is.na(.data[[col]])
+      .data[[col]][!miss_val] <- replace_val[.data[[col]][!miss_val]]
     }
 
     return(.data)

--- a/tests/testthat/test-encode-field-values.R
+++ b/tests/testthat/test-encode-field-values.R
@@ -16,3 +16,20 @@ test_that("encode_field_values() encodes field values", {
 
   expect_true(all(encoded_vals %in% domain_vals))
 })
+
+test_that("encode_field_values() encodes field values when field is set", {
+  skip_on_cran()
+  flayer <- arc_open(
+    "https://services1.arcgis.com/99lidPhWCzftIe9K/ArcGIS/rest/services/UtahRoads/FeatureServer/0"
+  )
+
+  res <- arc_select(layer, n_max = 100)
+
+  encoded <- encode_field_values(res, flayer, field = "CARTOCODE")
+
+  # fetch domains and known values
+  domains <- list_field_domains(layer, field = "CARTOCODE")
+  domain_vals <- domains[[c("CARTOCODE", "codedValues", "name")]]
+
+  expect_true(all(encoded[["CARTOCODE"]] %in% domain_vals))
+})


### PR DESCRIPTION
I haven't been able to figure out entirely but better handling for NA values by `encode_field_values()` avoids the error at least (although there is now a warning).

## Changes 

Minor change to leave missing values for encoded field columns in place.

**Issues that this closes** 

https://github.com/R-ArcGIS/arcgislayers/issues/237

https://github.com/R-ArcGIS/arcgislayers/issues/236