### PR TITLE
Add input checks for `get_layer` and related functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Improve handling of `filter_geom` by `arc_select()` by warning if applying `sf::st_union()` to the filter does not generate a length 1 sfc, or if `filter_geom` is supplied when accessing a Table, or if `filter_geom` is empty (@elipousson, #166)
 - Export `set_layer_aliases()` (previously used internally by `arc_read()`) to allow use of alias values with data returned by `arc_select()` (#169).
 - Add new `encode_field_values()` function to support replacement or labeling of values with coded value domains (#134).
+- Improve input checks for `get_layer()`, `get_all_layers()`, and `get_layers()` to require FeatureServer, MapServer, or GroupLayer input objects.
 
 ## Bug fixes
 

--- a/R/utils-feature-server.R
+++ b/R/utils-feature-server.R
@@ -1,9 +1,9 @@
 #' Extract a layer from a Feature or Map Server
 #'
 #' These helpers provide easy access to the layers contained in a
-#' `FeatureServer` or `MapServer`.
+#' `FeatureServer`, `MapServer`, or `GroupLayer`.
 #'
-#' @param x an object of class `FeatureServer` or `MapServer`
+#' @param x an object of class `FeatureServer`, `MapServer`, or `GroupLayer`.
 #' @param id default `NULL`. A numeric vector of unique ID of the layer you want to retrieve. This is a scalar in `get_layer()`.
 #' @param name default `NULL`. The name associated with the layer you want to retrieve. `name` is mutually exclusive with `id`. This is a scalar in `get_layer()`.
 #' @inheritParams arc_open
@@ -37,6 +37,8 @@
 #'   get_all_layers(fserv)
 #' }
 get_layer <- function(x, id = NULL, name = NULL, token = arc_token()) {
+  check_inherits_any(x, class = c("FeatureServer", "MapServer", "GroupLayer"))
+
   # check for mutual exclusivity between id and name
   if (is.null(id) && is.null(name)) {
     cli::cli_abort("{.arg id} or {.arg name} must be provided.")
@@ -149,6 +151,7 @@ get_layer.GroupLayer <- function(
 #' @rdname get_layer
 #' @export
 get_all_layers <- function(x, token = arc_token()) {
+  check_inherits_any(x, class = c("FeatureServer", "MapServer", "GroupLayer"))
   UseMethod("get_all_layers")
 }
 
@@ -189,6 +192,8 @@ get_layers <- function(
     name = NULL,
     token = arc_token()
 ) {
+  check_inherits_any(x, class = c("FeatureServer", "MapServer", "GroupLayer"))
+
   if (is.null(id) && is.null(name)) {
     cli::cli_abort("{.arg id} or {.arg name} must be provided.")
   } else if (!is.null(id) && !is.null(name)) {

--- a/man/get_layer.Rd
+++ b/man/get_layer.Rd
@@ -13,7 +13,7 @@ get_all_layers(x, token = arc_token())
 get_layers(x, id = NULL, name = NULL, token = arc_token())
 }
 \arguments{
-\item{x}{an object of class \code{FeatureServer} or \code{MapServer}}
+\item{x}{an object of class \code{FeatureServer}, \code{MapServer}, or \code{GroupLayer}.}
 
 \item{id}{default \code{NULL}. A numeric vector of unique ID of the layer you want to retrieve. This is a scalar in \code{get_layer()}.}
 
@@ -31,7 +31,7 @@ Each a list containing \code{FeatureLayer} and \code{Table}s respectively.
 }
 \description{
 These helpers provide easy access to the layers contained in a
-\code{FeatureServer} or \code{MapServer}.
+\code{FeatureServer}, \code{MapServer}, or \code{GroupLayer}.
 }
 \details{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/tests/testthat/test-get-all-layers.R
+++ b/tests/testthat/test-get-all-layers.R
@@ -1,3 +1,10 @@
+test_that("get_all_layers(): Must be `FeatureServer`, `MapServer` or `GroupLayer`", {
+  skip_on_cran()
+  server_url <- "https://services2.arcgis.com/j80Jz20at6Bi0thr/ArcGIS/rest/services/hexagons_state/FeatureServer"
+  expect_error(get_layers(server_url, 0))
+})
+
+
 test_that("get_all_layers(): FeatureServer", {
   skip_on_cran()
   server_url <- "https://services2.arcgis.com/j80Jz20at6Bi0thr/ArcGIS/rest/services/hexagons_state/FeatureServer"

--- a/tests/testthat/test-get-layer.R
+++ b/tests/testthat/test-get-layer.R
@@ -5,11 +5,15 @@ server_url <- "https://services2.arcgis.com/j80Jz20at6Bi0thr/ArcGIS/rest/service
 
 fsrv <- arc_open(server_url)
 
-test_that("get_layer(): Generic - name and id are mutually exclusive", {
+test_that("get_layer(): Must be `FeatureServer`, `MapServer` or `GroupLayer`", {
   skip_on_cran()
-  expect_error(get_layer(srv, 0, "break"))
+  expect_error(get_layer(server_url, 0))
 })
 
+test_that("get_layer(): Generic - name and id are mutually exclusive", {
+  skip_on_cran()
+  expect_error(get_layer(fsrv, 0, "break"))
+})
 
 test_that("get_layer(): `FeatureServer` by ID", {
   skip_on_cran()

--- a/tests/testthat/test-get-layers.R
+++ b/tests/testthat/test-get-layers.R
@@ -5,6 +5,11 @@ furl <- paste0(
 
 fsrv <- arc_open(furl)
 
+test_that("get_layers(): Must be `FeatureServer`, `MapServer` or `GroupLayer`", {
+  skip_on_cran()
+  expect_error(get_layers(furl, 0))
+})
+
 test_that("get_layers(): Mutually Exclusive", {
   expect_error(
     get_layers(fsrv, 0:1, name = c("Tracts", "ZCTAs"))


### PR DESCRIPTION
Add input checks for `get_layer`, `get_all_layers`, `get_layers` to require `FeatureServer`, `MapServer` or `GroupLayer` and avoid generic "subscript out of bounds" error message with invalid inputs. Also update docs to document support for GroupLayer input data and add tests for new input checks.

## Checklist 

- [X] update NEWS.md
- [X] documentation updated with `devtools::document()`

## Changes 

The new checks use the existing `check_inherits_any` helper function.

**Issues that this closes** 

I can add an issue if needed - this seemed small so I wasn't sure a separate issue was required.

## Follow up tasks

None that I can think of.