### PR TITLE
Fix issue w/ `encode_field_values()` (#237)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,14 @@
-# arcgislayers (development) 
+# arcgislayers (development)
+
+## New Features
 
 ## Bug Fixes
 
 - Improve `update_features()` with an error message when the `objectid` is not an `integer` ([#250](https://github.com/R-ArcGIS/arcgislayers/issues/250))
 - `get_layer()` warns as expected on invalid layer names values. ([#251](https://github.com/R-ArcGIS/arcgislayers/issues/251))
+- `encode_field_values()` handles numeric columns with coded value domains without warnings or errors. ([#237](https://github.com/R-ArcGIS/arcgislayers/issues/237))
 
-## New Features
-
-## Breaking changes 
+## Breaking changes
 
 # arcgislayers 0.4.0
 

--- a/man/encode_field_values.Rd
+++ b/man/encode_field_values.Rd
@@ -17,8 +17,9 @@ encode_field_values(
 
 \item{.layer}{A Table or FeatureLayer object. Required.}
 
-\item{field}{Default \code{NULL}. Field or fields to replace. Fields that do
-not have coded value domains are ignored.}
+\item{field}{Optional character vector with names of fields to replace.
+Fields that do not have coded value domains are ignored. Defaults to \code{NULL}
+to replace or label all fields with coded value domains.}
 
 \item{codes}{Use of field alias values. Defaults to \code{"replace"}.
 There are two options:

--- a/tests/testthat/test-encode-field-values.R
+++ b/tests/testthat/test-encode-field-values.R
@@ -17,19 +17,19 @@ test_that("encode_field_values() encodes field values", {
   expect_true(all(encoded_vals %in% domain_vals))
 })
 
-# test_that("encode_field_values() encodes field values when field is set", {
-#   skip_on_cran()
-#   flayer <- arc_open(
-#     "https://services1.arcgis.com/99lidPhWCzftIe9K/ArcGIS/rest/services/UtahRoads/FeatureServer/0"
-#   )
+test_that("encode_field_values() encodes field values when field is set", {
+  skip_on_cran()
+  flayer <- arc_open(
+    "https://services1.arcgis.com/99lidPhWCzftIe9K/ArcGIS/rest/services/UtahRoads/FeatureServer/0"
+  )
 
-#   res <- arc_select(layer, n_max = 100)
+  res <- arc_select(flayer, n_max = 100)
 
-#   encoded <- encode_field_values(res, flayer, field = "CARTOCODE")
+  encoded <- encode_field_values(res, flayer, field = "CARTOCODE")
 
-#   # fetch domains and known values
-#   domains <- list_field_domains(layer, field = "CARTOCODE")
-#   domain_vals <- domains[[c("CARTOCODE", "codedValues", "name")]]
+  # fetch domains and known values
+  domains <- list_field_domains(flayer, field = "CARTOCODE")
+  domain_vals <- domains[[c("CARTOCODE", "codedValues", "name")]]
 
-#   expect_true(all(encoded[["CARTOCODE"]] %in% domain_vals))
-# })
+  expect_true(all(encoded[["CARTOCODE"]] %in% domain_vals))
+})


### PR DESCRIPTION
Also restore test reported as problem #236

And clarify docs to explain default behavior for `field` argument

## Checklist 

- [X] update NEWS.md
- [X] documentation updated with `devtools::document()`
- [X] `devtools::check()` passes locally

## Changes 

Correct `encode_field_values()` handling of numeric columns with coded value domains (which was the source of the persistent warning initially reported here as an error: #237

## Follow up tasks

None at this time.