### PR TITLE
Add `build_layer_query()` helper

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,9 @@
 # arcgislayers (development)
 
-## New Features
-
 ## New features
 
 - `add_definition()` (#178), `update_definition()` (#127), and `delete_definition()` functions for FeatureServer and FeatureLayer objects.
+- `arc_select()` allows arguments with numeric and logical values (as well as strings) to be passed via `...`. This change allows users to specify `returnDistinctValues = TRUE` in combination with select `fields` ([#233](https://github.com/R-ArcGIS/arcgislayers/issues/233)) and improves validation of any parameters passed via `...` ([#266](https://github.com/R-ArcGIS/arcgislayers/issues/266)).
 
 ## Bug Fixes
 

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -196,8 +196,6 @@ build_layer_query <- function(
       "{.arg filter_geom} is ignored when {.arg x} is
       {.obj_simple_type {.cls {class(x)}}}."
     )
-
-    filter_geom <- NULL
   }
 
   # handle SR if not missing


### PR DESCRIPTION
This is a minor refactor to add support for the `returnDistinctValues` argument (per #233) and address outstanding issues flagged in #226. The PR includes:

- Add `build_layer_query` helper
- Add a supporting `check_query_value` helper
- Alert user if returnGeometry is provided separately from geometry or outFields provided separately from fields
- Drop geometry from output when `returnGeometry=FALSE` (only an issue if `returnDistinctValues=TRUE`)
- Relocate check for n_max to `validate_results_count`

## Checklist 

- [X] `devtools::check()` passes locally
- [x] update NEWS.md

No changes to documentation.

## Changes 

The `build_layer_query()` helper consolidates the code within `arc_select()` that updates the query and improves readability (IMHO) while also improving the handling of any dots arguments.

**Issues that this closes** 

#233 and #226

## Follow up tasks

None at this time.