### PR TITLE
Fix misnamed variable (definition -> delete_definition)

### DIFF
--- a/R/arc-definition.R
+++ b/R/arc-definition.R
@@ -183,7 +183,7 @@ delete_definition <- function(
   check_resp_body_error(resp = resp)
 
   print_definition_values(
-    definition,
+    delete_definition,
     what = class(x),
     action = "Deleted"
   )


### PR DESCRIPTION
## Changes 

This corrects a typo in `delete_definition()` where the `delete_definition` variable is referenced as `definition` instead. The fix addresses a note that showed up in `devtools::check()` for the other PR I just opened.

## Follow up tasks

None.