### PR TITLE
Fix handling of blank coded values

### DIFF
--- a/R/arc-read.R
+++ b/R/arc-read.R
@@ -460,7 +460,7 @@ encode_field_values <- function(
       col_val <- as.character(.data[[col]])
 
       # Replace column values if not all missing or empty strings
-      miss_val <- is.na(col_val) | col_val != ""
+      miss_val <- is.na(col_val) | col_val == ""
       if (any(!miss_val)) {
         replace_val <- values[[col]]
         col_val[!miss_val] <- replace_val[col_val[!miss_val]]

--- a/R/arc-read.R
+++ b/R/arc-read.R
@@ -459,12 +459,12 @@ encode_field_values <- function(
       # Coerce numeric columns to character
       col_val <- as.character(.data[[col]])
 
-      # Replace column values if not all missing
-      miss_val <- is.na(col_val)
-      if (!all(miss_val)) {
+      # Replace column values if not all missing or empty strings
+      miss_val <- is.na(col_val) | col_val != ""
+      if (any(!miss_val)) {
         replace_val <- values[[col]]
-        col_replace <- replace_val[col_val[!miss_val]]
-        .data[[col]][!miss_val] <- col_replace
+        col_val[!miss_val] <- replace_val[col_val[!miss_val]]
+        .data[[col]] <- col_val
       }
     }
 

--- a/R/arc-read.R
+++ b/R/arc-read.R
@@ -463,6 +463,20 @@ encode_field_values <- function(
       miss_val <- is.na(col_val) | col_val == ""
       if (any(!miss_val)) {
         replace_val <- values[[col]]
+        bad_val <- !(col_val %in% names(replace_val)) & !miss_val
+
+        # warn on invalid values
+        if (any(bad_val)) {
+          bad_val_unique <- unique(col_val[bad_val])
+          cli::cli_alert_info(
+            "{col} contains {length(bad_val_unique)} value{?s} that {?is/are} not included in the coded values for the field: {.str {bad_val_unique}}"
+          )
+
+          # TODO: Allow option to turn bad values to NA values
+          # col_val[bad_val] <- NA_character_
+          miss_val <- miss_val | bad_val
+        }
+
         col_val[!miss_val] <- replace_val[col_val[!miss_val]]
         .data[[col]] <- col_val
       }


### PR DESCRIPTION
Possible fix for #263

Without a reprex, I'm not certain if this is a complete fix but I found that coded value columns may include invalid or blank values as well as missing values, e.g. this example:

 ``` r
library(arcgislayers)

layer <- arc_open(
  "https://services1.arcgis.com/99lidPhWCzftIe9K/ArcGIS/rest/services/UtahRoads/FeatureServer/0"
)

feats <- arc_select(layer, n_max = 10000)

arcgislayers:::pull_coded_values(layer, field = "BIKE_REGPR")[[1]]
#>         Y         N         U 
#>     "Yes"      "No" "Unknown"

unique(feats[["BIKE_REGPR"]])
#> [1] NA      ""      "Local"
```

<sup>Created on 2025-06-24 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This change counts empty strings as missing values and leaves them in place when replacing coded values. It also alerts on "invalid" values that don't have a corresponding code and leaves those in place. That makes `encode_field_values()` a lot noisier but I'm unsure how else to handle it.