### PR TITLE
New option to override interactive mode in the add_features function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 - `add_attachment()`: a new function to add attachments to a set of features in a feature layer.
 - Adds `llms.txt`
+- `add_features()` now has an option `interactive` that can force it to run in non-interactive mode.
 
 ## Bug Fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,12 @@
 
 - `add_attachment()`: a new function to add attachments to a set of features in a feature layer.
 - Adds `llms.txt`
-- `add_features()` now has an option `interactive` that can force it to run in non-interactive mode.
+
 
 ## Bug Fixes
 
 - `arc_select()` returns an empty `data.frame` instead of `NULL` when no features are returned from a query
-
+- `add_features()` uses `rlang::is_interactive()` to determine if the user is running in an interactive session instead of `base::interactive()`. This allows for the specification of which mode the function should run in using `rlang::with_interactive()` or `rlang::local_interactive()`.
 
 
 ## Breaking changes

--- a/R/arc-add-delete.R
+++ b/R/arc-add-delete.R
@@ -10,6 +10,7 @@
 #' @param rollback_on_failure if anything errors, roll back writes.
 #'  Defaults to `TRUE`.
 #' @param progress default `TRUE`. A progress bar to be rendered by `httr2` to track requests.
+#' @param interactive default `TRUE`. Force everything to run in specified interactive mode.
 #' @param token your authorization token.
 #'
 #' @inheritParams arc_select
@@ -54,6 +55,7 @@ add_features <- function(
   match_on = c("name", "alias"),
   rollback_on_failure = TRUE,
   progress = TRUE,
+  interactive = TRUE,
   token = arc_token()
 ) {
   # initial check for type of `x`
@@ -102,7 +104,8 @@ add_features <- function(
 
   inform_nin_feature(
     # columns not in the feature layer
-    setdiff(cnames[!present_index], geo_col)
+    setdiff(cnames[!present_index], geo_col),
+    interactive
   )
 
   # subset accordingly
@@ -173,7 +176,11 @@ add_features <- function(
 
 
 #' @noRd
-inform_nin_feature <- function(nin_feature, error_call = rlang::caller_call()) {
+inform_nin_feature <- function(
+  nin_feature,
+  interactive_state,
+  error_call = rlang::caller_call()
+) {
   if (length(nin_feature) == 0) {
     return(invisible(NULL))
   }
@@ -190,7 +197,7 @@ inform_nin_feature <- function(nin_feature, error_call = rlang::caller_call()) {
     )
   )
 
-  if (interactive()) {
+  if (interactive() && interactive_state) {
     cont <- utils::menu(
       c("Yes", "No"),
       title = "Columns not found in feature service. Would you like to continue?"

--- a/R/arc-add-delete.R
+++ b/R/arc-add-delete.R
@@ -11,6 +11,7 @@
 #'  Defaults to `TRUE`.
 #' @param progress default `TRUE`. A progress bar to be rendered by `httr2` to track requests.
 #' @param interactive default `TRUE`. Force everything to run in specified interactive mode.
+#' @param ignore_exra_cols default `FALSE`. Ignore columns that are in `.data` but not in Feature Layer.
 #' @param token your authorization token.
 #'
 #' @inheritParams arc_select
@@ -56,6 +57,7 @@ add_features <- function(
   rollback_on_failure = TRUE,
   progress = TRUE,
   interactive = TRUE,
+  ignore_extra_cols = FALSE,
   token = arc_token()
 ) {
   # initial check for type of `x`
@@ -101,12 +103,13 @@ add_features <- function(
     }
     colnames(.data) <- cnames
   }
-
-  inform_nin_feature(
-    # columns not in the feature layer
-    setdiff(cnames[!present_index], geo_col),
-    interactive
-  )
+  if (!ignore_extra_cols) {
+    inform_nin_feature(
+      # columns not in the feature layer
+      setdiff(cnames[!present_index], geo_col),
+      interactive
+    )
+  }
 
   # subset accordingly
   .data <- .data[, present_index, drop = FALSE]

--- a/R/arc-add-delete.R
+++ b/R/arc-add-delete.R
@@ -10,8 +10,6 @@
 #' @param rollback_on_failure if anything errors, roll back writes.
 #'  Defaults to `TRUE`.
 #' @param progress default `TRUE`. A progress bar to be rendered by `httr2` to track requests.
-#' @param interactive default `TRUE`. Force everything to run in specified interactive mode.
-#' @param ignore_exra_cols default `FALSE`. Ignore columns that are in `.data` but not in Feature Layer.
 #' @param token your authorization token.
 #'
 #' @inheritParams arc_select
@@ -56,8 +54,6 @@ add_features <- function(
   match_on = c("name", "alias"),
   rollback_on_failure = TRUE,
   progress = TRUE,
-  interactive = TRUE,
-  ignore_extra_cols = FALSE,
   token = arc_token()
 ) {
   # initial check for type of `x`
@@ -106,8 +102,7 @@ add_features <- function(
   if (!ignore_extra_cols) {
     inform_nin_feature(
       # columns not in the feature layer
-      setdiff(cnames[!present_index], geo_col),
-      interactive
+      setdiff(cnames[!present_index], geo_col)
     )
   }
 
@@ -181,7 +176,6 @@ add_features <- function(
 #' @noRd
 inform_nin_feature <- function(
   nin_feature,
-  interactive_state,
   error_call = rlang::caller_call()
 ) {
   if (length(nin_feature) == 0) {
@@ -200,7 +194,7 @@ inform_nin_feature <- function(
     )
   )
 
-  if (interactive() && interactive_state) {
+  if (rlang::is_interactive()) {
     cont <- utils::menu(
       c("Yes", "No"),
       title = "Columns not found in feature service. Would you like to continue?"

--- a/R/arc-add-delete.R
+++ b/R/arc-add-delete.R
@@ -99,12 +99,10 @@ add_features <- function(
     }
     colnames(.data) <- cnames
   }
-  if (!ignore_extra_cols) {
-    inform_nin_feature(
-      # columns not in the feature layer
-      setdiff(cnames[!present_index], geo_col)
-    )
-  }
+  inform_nin_feature(
+    # columns not in the feature layer
+    setdiff(cnames[!present_index], geo_col)
+  )
 
   # subset accordingly
   .data <- .data[, present_index, drop = FALSE]

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -13,8 +13,6 @@ add_features(
   match_on = c("name", "alias"),
   rollback_on_failure = TRUE,
   progress = TRUE,
-  interactive = TRUE,
-  ignore_extra_cols = FALSE,
   token = arc_token()
 )
 
@@ -55,8 +53,6 @@ applied only if all submitted edits succeed.}
 
 \item{progress}{default \code{TRUE}. A progress bar to be rendered by \code{httr2} to track requests.}
 
-\item{interactive}{default \code{TRUE}. Force everything to run in specified interactive mode.}
-
 \item{token}{default \code{arc_token()}. An \code{httr2_token}.}
 
 \item{object_ids}{a numeric vector of object IDs to be deleted.}
@@ -71,8 +67,6 @@ query results based on a predicate function.}
 \item{predicate}{Spatial predicate to use with \code{filter_geom}. Default
 \code{"intersects"}. Possible options are \code{"intersects"}, \code{"contains"},
 \code{"crosses"},  \code{"overlaps"},  \code{"touches"}, and \code{"within"}.}
-
-\item{ignore_exra_cols}{default \code{FALSE}. Ignore columns that are in \code{.data} but not in Feature Layer.}
 }
 \value{
 \itemize{

--- a/man/modify.Rd
+++ b/man/modify.Rd
@@ -13,6 +13,8 @@ add_features(
   match_on = c("name", "alias"),
   rollback_on_failure = TRUE,
   progress = TRUE,
+  interactive = TRUE,
+  ignore_extra_cols = FALSE,
   token = arc_token()
 )
 
@@ -53,6 +55,8 @@ applied only if all submitted edits succeed.}
 
 \item{progress}{default \code{TRUE}. A progress bar to be rendered by \code{httr2} to track requests.}
 
+\item{interactive}{default \code{TRUE}. Force everything to run in specified interactive mode.}
+
 \item{token}{default \code{arc_token()}. An \code{httr2_token}.}
 
 \item{object_ids}{a numeric vector of object IDs to be deleted.}
@@ -67,6 +71,8 @@ query results based on a predicate function.}
 \item{predicate}{Spatial predicate to use with \code{filter_geom}. Default
 \code{"intersects"}. Possible options are \code{"intersects"}, \code{"contains"},
 \code{"crosses"},  \code{"overlaps"},  \code{"touches"}, and \code{"within"}.}
+
+\item{ignore_exra_cols}{default \code{FALSE}. Ignore columns that are in \code{.data} but not in Feature Layer.}
 }
 \value{
 \itemize{


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally

## Changes 

Modified the `add_features()` function to force-override `interactive` mode. This solves an issue I was having when using this in an ArcGIS Pro script tool, where the script would get ran in `interactive` mode despite there being no way to interact with the R console. I encountered a situation where the target feature layer didn't have all the fields of the input layer and the function prompted as if it was in `interactive` mode, but I was unable to cancel the prompt or respond to it and had to restart ArcGIS Pro to run the tool again. @JosiahParry unsure if you or the team is aware of this. Let me know if I should create an issue in another repo.



## Follow up tasks

- Check code, let me know if anything needs to be revised.

