### PR TITLE
Use arcgisutils::from_spatial_reference() to allow for ESRI CRSs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,9 @@ Authors@R: c(
     person("Martha", "Bass", role = "ctb",
            comment = c(ORCID = "0009-0004-0268-5426")),
     person("Antony", "Barja", role = "ctb",
-           comment = c(ORCID = "0000-0001-5921-2858"))
+           comment = c(ORCID = "0000-0001-5921-2858")),
+    person("Ryan", "Zomorrodi", , "ryanzomorrodi@gmail.com", role = "ctb",
+           comment = c(ORCID = "0009-0003-6417-5985"))
   )
 Description: Enables users of 'ArcGIS Enterprise', 'ArcGIS Online', or
     'ArcGIS Platform' to read, write, publish, or manage vector and raster

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ## Bug Fixes
 
+- `st_crs()` on a FeatureLayer or ImageServer uses `arcgisutils::from_spatial_reference()`. This allows for support of data with a CRS within the ESRI authority ([#291](https://github.com/R-ArcGIS/arcgislayers/issues/291))
 - `arc_select()` returns an empty `data.frame` instead of `NULL` when no features are returned from a query
 - `add_features()` uses `rlang::is_interactive()` to determine if the user is running in an interactive session instead of `base::interactive()`. This allows for the specification of which mode the function should run in using `rlang::with_interactive()` or `rlang::local_interactive()`.
 

--- a/R/sf-methods.R
+++ b/R/sf-methods.R
@@ -5,7 +5,11 @@ st_crs.FeatureLayer <- function(obj, ...) {
 }
 
 st_crs.ImageServer <- function(obj, ...) {
-  spatialReference <- obj[["extent"]][["spatialReference"]]
+ if (rlang::has_name(obj, "extent")) {
+    spatialReference <- obj[["extent"]][["spatialReference"]]
+  } else {
+    spatialReference <- obj[["spatialReference"]] %||% list()
+  }
   arcgisutils::from_spatial_reference(spatialReference)
 }
 

--- a/R/sf-methods.R
+++ b/R/sf-methods.R
@@ -1,36 +1,12 @@
 # st_crs method for feature layer
 st_crs.FeatureLayer <- function(obj, ...) {
-  arc_sr_as_crs(obj)
+  spatialReference <- obj[["spatialReference"]] %||% list()
+  arcgisutils::from_spatial_reference(spatialReference)
 }
 
 st_crs.ImageServer <- function(obj, ...) {
-  arc_sr_as_crs(obj)
-}
-
-#' Get a Coordinate Reference System from a FeatureLayer or ImageServer spatial
-#' reference
-#'
-#' arc_sr_as_crs() converts a FeatureLayer or ImageServer into a coordinate
-#' reference system (CRS) using sf::st_crs().
-#'
-#' @param x A FeatureLayer or ImageServer or another object with a named
-#'   `"spatialReference"` element that can be converted to a coordinate
-#'   reference system with [sf::st_crs()].
-#' @seealso [arcgisutils::validate_crs()]
-#' @returns An object of class crs of length 2.
-#' @noRd
-arc_sr_as_crs <- function(x) {
-  if (rlang::has_name(x, "extent")) {
-    spatialReference <- x[["extent"]][["spatialReference"]]
-  } else {
-    spatialReference <- x[["spatialReference"]] %||% list()
-  }
-
-  x_crs <- spatialReference[["latestWkid"]] %||%
-    spatialReference[["wkid"]] %||%
-    spatialReference[["wkt"]]
-
-  sf::st_crs(x_crs)
+  spatialReference <- obj[["extent"]][["spatialReference"]]
+  arcgisutils::from_spatial_reference(spatialReference)
 }
 
 # Implement `st_transform()`


### PR DESCRIPTION
## Checklist 

- [x] update NEWS.md
- [x] documentation updated with `devtools::document()`
- [x] `devtools::check()` passes locally
  There's an error in one of the tests that deals with respecting a crs argument provided by the user, but it seems to fail before this change as well

## Changes 

This just changes the `st_crs()` methods to use `arcgisutils::from_spatial_reference()` under the hood. This removes the need for `arc_sr_as_crs()`

**Issues that this closes** 
This PR is 2 of 3 aimed at solving https://github.com/R-ArcGIS/arcgislayers/issues/291.

## Follow up tasks

Since arcpbf is responsible for setting the crs of the response objects, I will make a PR to make arcpbf also use  `arcgisutils::from_spatial_reference()`,