### PR TITLE
arc_select fixes: #226 #242 #248 #283 #291

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - Adds `yyjsonr` as a dependency and fixes a bug where `NULL` values were serialized as `{}` when publishing an item
 - `arc_select()` aborts when a name in `...` is a near-miss of one of its arguments. `wher = "1=1"` was previously forwarded to the service, ignored, and every feature returned ([#226](https://github.com/R-ArcGIS/arcgislayers/issues/226))
 - `arc_select(fields = "")` returns geometry only for a layer, and rows without columns for a table. It previously aborted with `argument is of length zero` ([#248](https://github.com/R-ArcGIS/arcgislayers/issues/248))
+- `arc_select()` retries transient request failures and, if a page still fails, reports how many failed and why. Failed pages were previously passed to the parser as if they were responses, surfacing as `subscript out of bounds` ([#242](https://github.com/R-ArcGIS/arcgislayers/issues/242), [#283](https://github.com/R-ArcGIS/arcgislayers/issues/283))
 
 # arcgislayers 0.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # arcgislayers 0.6.1
 
 - Adds `yyjsonr` as a dependency and fixes a bug where `NULL` values were serialized as `{}` when publishing an item
+- `arc_select()` aborts when a name in `...` is a near-miss of one of its arguments. `wher = "1=1"` was previously forwarded to the service, ignored, and every feature returned ([#226](https://github.com/R-ArcGIS/arcgislayers/issues/226))
 
 # arcgislayers 0.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Adds `yyjsonr` as a dependency and fixes a bug where `NULL` values were serialized as `{}` when publishing an item
 - `arc_select()` aborts when a name in `...` is a near-miss of one of its arguments. `wher = "1=1"` was previously forwarded to the service, ignored, and every feature returned ([#226](https://github.com/R-ArcGIS/arcgislayers/issues/226))
+- `arc_select(fields = "")` returns geometry only for a layer, and rows without columns for a table. It previously aborted with `argument is of length zero` ([#248](https://github.com/R-ArcGIS/arcgislayers/issues/248))
 
 # arcgislayers 0.6.0
 

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -244,7 +244,7 @@ arc_select <- function(
   }
 
   # if the result is empty we return a nothing with a message
-  if (rlang::is_empty(res)) {
+  if (NROW(res) == 0L) {
     cli::cli_alert_info("No features returned from query")
     return(arcgisutils::fields_as_ptype_df(list_fields(x)))
   }

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -113,6 +113,7 @@ arc_select <- function(
 
   # extract dots names
   dots_names <- names(dots)
+  check_dots_query_names(dots_names, call = error_call)
 
   # insert into query
   for (i in seq_along(dots)) {
@@ -395,6 +396,45 @@ update_params <- function(x, ...) {
 
   attr(x, "query") <- query
   x
+}
+
+# `...` forwards arbitrary Esri query parameters, so only near-misses of a real
+# argument are treated as typos.
+check_dots_query_names <- function(
+  dots_names,
+  call = rlang::caller_env()
+) {
+  if (rlang::is_empty(dots_names)) {
+    return(invisible(dots_names))
+  }
+
+  args <- c(
+    "fields",
+    "where",
+    "crs",
+    "geometry",
+    "filter_geom",
+    "predicate",
+    "n_max",
+    "page_size",
+    "token"
+  )
+
+  dists <- utils::adist(dots_names, args, ignore.case = TRUE)
+  closest <- args[max.col(-dists, ties.method = "first")]
+  typos <- apply(dists, 1, min) <= 2
+
+  if (any(typos)) {
+    cli::cli_abort(
+      c(
+        "Unknown argument{?s} in {.arg ...}: {.arg {dots_names[typos]}}",
+        "i" = "Did you mean {.arg {closest[typos]}}?"
+      ),
+      call = call
+    )
+  }
+
+  invisible(dots_names)
 }
 
 #' Add an offset to a query parameters

--- a/R/arc-select.R
+++ b/R/arc-select.R
@@ -172,7 +172,11 @@ arc_select <- function(
   x <- update_params(x, !!!query)
 
   # sets token and agent
-  req <- arc_base_req(x[["url"]], token)
+  req <- httr2::req_retry(
+    arc_base_req(x[["url"]], token),
+    max_tries = 3,
+    retry_on_failure = TRUE
+  )
 
   # extract existing query
   query <- attr(x, "query")
@@ -304,7 +308,28 @@ get_query_resps <- function(
   )
 
   # make all requests and store responses in list
-  httr2::req_perform_parallel(all_requests, on_error = "continue")
+  all_resps <- httr2::req_perform_parallel(all_requests, on_error = "continue")
+
+  check_resp_failures(all_resps, call = error_call)
+}
+
+# req_perform_parallel(on_error = "continue") returns condition objects for
+# failed pages, which every downstream parser treats as responses
+check_resp_failures <- function(resps, call = rlang::caller_env()) {
+  failed <- vapply(resps, inherits, logical(1), what = "error")
+
+  if (!any(failed)) {
+    return(resps)
+  }
+
+  cli::cli_abort(
+    c(
+      "{sum(failed)} of {length(resps)} page{?s} failed to download.",
+      "x" = conditionMessage(resps[[which(failed)[1]]]),
+      "i" = "Retry, or lower {.arg page_size} if the service is timing out."
+    ),
+    call = call
+  )
 }
 
 

--- a/R/sf-methods.R
+++ b/R/sf-methods.R
@@ -5,7 +5,7 @@ st_crs.FeatureLayer <- function(obj, ...) {
 }
 
 st_crs.ImageServer <- function(obj, ...) {
- if (rlang::has_name(obj, "extent")) {
+  if (rlang::has_name(obj, "extent")) {
     spatialReference <- obj[["extent"]][["spatialReference"]]
   } else {
     spatialReference <- obj[["spatialReference"]] %||% list()

--- a/tests/testthat/_snaps/get-layers.new.md
+++ b/tests/testthat/_snaps/get-layers.new.md
@@ -1,0 +1,131 @@
+# get_layers(): FeatureServer ID
+
+    Code
+      get_layers(fsrv, 0:1)
+    Output
+      [[1]]
+      <FeatureLayer>
+      Name: PlacePoints
+      Geometry Type: esriGeometryPoint
+      CRS: 3785
+      Capabilities: Query,Extract
+      
+      [[2]]
+      <FeatureLayer>
+      Name: PlaceBoundaries
+      Geometry Type: esriGeometryPolygon
+      CRS: 3785
+      Capabilities: Query,Extract
+      
+
+# get_layers(): FeatureServer name
+
+    Code
+      get_layers(fsrv, name = c("Tracts", "ZCTAs"))
+    Output
+      [[1]]
+      <FeatureLayer>
+      Name: Tracts
+      Geometry Type: esriGeometryPolygon
+      CRS: 3785
+      Capabilities: Query,Extract
+      
+      [[2]]
+      <FeatureLayer>
+      Name: ZCTAs
+      Geometry Type: esriGeometryPolygon
+      CRS: 3785
+      Capabilities: Query,Extract
+      
+
+# get_layers(): MapServer ID
+
+    Code
+      get_layers(msrv, 1:2)
+    Output
+      [[1]]
+      <FeatureLayer>
+      Name: Census Block Group
+      Geometry Type: esriGeometryPolygon
+      CRS: 4269
+      Capabilities: Map,Query,Data
+      
+      [[2]]
+      <FeatureLayer>
+      Name: Detailed Counties
+      Geometry Type: esriGeometryPolygon
+      CRS: 4269
+      Capabilities: Map,Query,Data
+      
+
+# get_layers(): MapServer name
+
+    Code
+      get_layers(msrv, name = c("Census Block Points", "Census Block Group"))
+    Output
+      [[1]]
+      <FeatureLayer>
+      Name: Census Block Points
+      Geometry Type: esriGeometryPoint
+      CRS: 4269
+      Capabilities: Map,Query,Data
+      
+      [[2]]
+      <FeatureLayer>
+      Name: Census Block Group
+      Geometry Type: esriGeometryPolygon
+      CRS: 4269
+      Capabilities: Map,Query,Data
+      
+
+# get_layers(): GroupLayer ID
+
+    Code
+      get_layers(glyr, 1:2)
+    Output
+      [[1]]
+      <FeatureLayer>
+      Name: Bus Stops
+      Geometry Type: esriGeometryPoint
+      CRS: 2248
+      Capabilities: Map,Query,Data
+      
+      [[2]]
+      <FeatureLayer>
+      Name: Bus Routes
+      Geometry Type: esriGeometryPolyline
+      CRS: 2248
+      Capabilities: Map,Query,Data
+      
+
+# get_layers(): GroupLayer name
+
+    Code
+      get_layers(glyr, name = c("Bus Stops", "Bus Routes"))
+    Output
+      [[1]]
+      <FeatureLayer>
+      Name: Bus Stops
+      Geometry Type: esriGeometryPoint
+      CRS: 2248
+      Capabilities: Map,Query,Data
+      
+      [[2]]
+      <FeatureLayer>
+      Name: Bus Routes
+      Geometry Type: esriGeometryPolyline
+      CRS: 2248
+      Capabilities: Map,Query,Data
+      
+
+# get_layers(): can fetch Table
+
+    Code
+      get_layers(fsrv, 1)
+    Output
+      [[1]]
+      <Table>
+      Name: Pop_Up_Table
+      Capabilities: Query,Sync
+      
+

--- a/tests/testthat/test-esri-authority-crs.R
+++ b/tests/testthat/test-esri-authority-crs.R
@@ -1,0 +1,36 @@
+feature_layer <- function(sr) {
+  structure(list(spatialReference = sr), class = c("FeatureLayer", "list"))
+}
+
+image_server <- function(sr) {
+  structure(
+    list(extent = list(spatialReference = sr)),
+    class = c("ImageServer", "list")
+  )
+}
+
+test_that("st_crs() resolves ESRI authority wkids (#291)", {
+  expect_identical(
+    sf::st_crs(feature_layer(list(wkid = 102003L))),
+    sf::st_crs("ESRI:102003")
+  )
+  expect_false(is.na(sf::st_crs(feature_layer(list(wkid = 102003L)))))
+})
+
+test_that("st_crs() resolves EPSG wkids (#291)", {
+  expect_identical(
+    sf::st_crs(feature_layer(list(wkid = 4326L))),
+    sf::st_crs(4326)
+  )
+})
+
+test_that("st_crs() reads an ImageServer extent (#291)", {
+  expect_identical(
+    sf::st_crs(image_server(list(wkid = 102003L))),
+    sf::st_crs("ESRI:102003")
+  )
+})
+
+test_that("st_crs() returns NA for a missing spatial reference (#291)", {
+  expect_true(is.na(sf::st_crs(feature_layer(NULL))))
+})

--- a/tests/testthat/test-resp-failures.R
+++ b/tests/testthat/test-resp-failures.R
@@ -1,0 +1,31 @@
+failed_resp <- function(msg = "Connection timed out") {
+  structure(
+    class = c("httr2_failure", "httr2_error", "error", "condition"),
+    list(message = msg, call = NULL)
+  )
+}
+
+test_that("check_resp_failures() passes clean responses through", {
+  resps <- list(structure(list(), class = "httr2_response"))
+  expect_no_error(check_resp_failures(resps))
+  expect_identical(check_resp_failures(resps), resps)
+})
+
+test_that("check_resp_failures() aborts naming how many pages failed", {
+  resps <- list(
+    structure(list(), class = "httr2_response"),
+    failed_resp(),
+    failed_resp()
+  )
+
+  expect_error(check_resp_failures(resps), "2 of 3")
+})
+
+test_that("check_resp_failures() surfaces the underlying message", {
+  resps <- list(failed_resp("Connection timed out"))
+  expect_error(check_resp_failures(resps), "Connection timed out")
+})
+
+test_that("check_resp_failures() tolerates an empty list", {
+  expect_no_error(check_resp_failures(list()))
+})

--- a/tests/testthat/test-select-dots.R
+++ b/tests/testthat/test-select-dots.R
@@ -1,0 +1,43 @@
+fake_layer <- function() {
+  structure(
+    list(
+      capabilities = "Query",
+      fields = data.frame(name = "A", type = "esriFieldTypeString"),
+      spatialReference = list(wkid = 4326L)
+    ),
+    class = c("FeatureLayer", "list"),
+    query = list()
+  )
+}
+
+test_that("arc_select() catches misspelled arguments (#226)", {
+  expect_error(arc_select(fake_layer(), wher = "1=1"), "where")
+  expect_error(arc_select(fake_layer(), field = "A"), "fields")
+  expect_error(arc_select(fake_layer(), n_mx = 1), "n_max")
+})
+
+test_that("arc_select() catches wrong case (#226)", {
+  expect_error(arc_select(fake_layer(), Where = "1=1"), "where")
+  expect_error(arc_select(fake_layer(), CRS = 4326), "crs")
+})
+
+test_that("arc_select() names the offending argument (#226)", {
+  expect_error(arc_select(fake_layer(), wher = "1=1"), "wher")
+})
+
+test_that("arc_select() still allows Esri query parameters (#226)", {
+  for (nm in c(
+    "outSR",
+    "resultType",
+    "orderByFields",
+    "returnDistinctValues"
+  )) {
+    dots <- setNames(list("1"), nm)
+    expect_no_error(do.call(check_dots_query_names, list(names(dots))))
+  }
+})
+
+test_that("check_dots_query_names() tolerates no dots (#226)", {
+  expect_no_error(check_dots_query_names(character()))
+  expect_no_error(check_dots_query_names(NULL))
+})

--- a/tests/testthat/test-select-no-fields.R
+++ b/tests/testthat/test-select-no-fields.R
@@ -1,0 +1,33 @@
+test_that("arc_select() returns geometry only for a layer (#248)", {
+  skip_on_cran()
+  furl <- "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/PLACES_LocalData_for_BetterHealth/FeatureServer/0"
+  flayer <- arc_open(furl)
+
+  res <- arc_select(flayer, fields = "", n_max = 10)
+
+  expect_s3_class(res, "sf")
+  expect_identical(nrow(res), 10L)
+  expect_identical(names(res), attr(res, "sf_column"))
+})
+
+test_that("arc_select() returns rows without columns for a table (#248)", {
+  skip_on_cran()
+  furl <- "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_Wetlands/FeatureServer/1"
+  tblayer <- arc_open(furl)
+
+  res <- arc_select(tblayer, fields = "", n_max = 100)
+
+  expect_identical(dim(res), c(100L, 0L))
+})
+
+test_that("arc_select() still reports genuinely empty results (#248)", {
+  skip_on_cran()
+  furl <- "https://services3.arcgis.com/ZvidGQkLaDJxRSJ2/arcgis/rest/services/PLACES_LocalData_for_BetterHealth/FeatureServer/0"
+  flayer <- arc_open(furl)
+
+  expect_message(
+    res <- arc_select(flayer, where = "1 = 0"),
+    "No features returned"
+  )
+  expect_identical(nrow(res), 0L)
+})


### PR DESCRIPTION
- **test: cover ESRI authority CRS resolution, closes #291**
- **fix(select): catch misspelled arguments in ..., closes #226**
- **fix(select): support querying no fields, closes #248**
- **fix(select): handle failed pages, closes #242, closes #283**
